### PR TITLE
Improve selection highlight contrast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2129,10 +2129,10 @@ fn render_column(
 fn render_card(frame: &mut Frame, area: Rect, card: &Card, is_selected: bool, is_related: bool) {
     let border_style = if is_selected {
         Style::default()
-            .fg(Color::White)
+            .fg(Color::Rgb(255, 200, 50))
             .add_modifier(Modifier::BOLD)
     } else if is_related {
-        Style::default().fg(Color::Cyan)
+        Style::default().fg(Color::Rgb(100, 100, 100))
     } else {
         Style::default().fg(Color::DarkGray)
     };


### PR DESCRIPTION
## Summary
- Changed selected card border from `Color::White` to bright gold (`RGB 255, 200, 50`) with bold for stronger visual prominence
- Toned down related card borders from `Color::Cyan` to subtle gray (`RGB 100, 100, 100`) so they no longer overshadow the selection
- Default unselected cards remain `DarkGray`, preserving the visual hierarchy

The previous selection highlight (white bold border) was hard to distinguish from the related card highlights (cyan), which were more eye-catching. This swaps the emphasis so the selected item is the most visually prominent element.

## Test plan
- [ ] Launch the TUI and navigate between cards
- [ ] Verify the selected card has a bright gold border that stands out clearly
- [ ] Verify related cards have a subtle gray border that is visible but not distracting
- [ ] Verify unselected/unrelated cards remain dark gray

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)