### PR TITLE
Fix related card highlighting visibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2272,7 +2272,7 @@ fn render_card(frame: &mut Frame, area: Rect, card: &Card, is_selected: bool, is
             .fg(Color::Rgb(255, 200, 50))
             .add_modifier(Modifier::BOLD)
     } else if is_related {
-        Style::default().fg(Color::Rgb(100, 100, 100))
+        Style::default().fg(Color::Rgb(180, 160, 100))
     } else {
         Style::default().fg(Color::DarkGray)
     };


### PR DESCRIPTION
## Summary
- Fixed related card highlighting being indistinguishable from normal (unrelated) cards
- Commit `0376a42` changed the related card border from `Cyan` to `RGB(100, 100, 100)`, which is nearly identical to the normal card border color (`DarkGray`), making related highlighting effectively invisible
- Changed the related card border to a muted warm gold (`RGB(180, 160, 100)`) that is clearly visible while remaining subtler than the selected card's bright gold (`RGB(255, 200, 50)`)

## Test plan
- [ ] Select an issue card and verify related worktrees, sessions, and PRs highlight in the other columns
- [ ] Select a worktree/session/PR and verify the related issue highlights
- [ ] Verify the selected card's bright gold border remains distinct from the related cards' muted gold border
- [ ] Verify unrelated cards still show dark gray borders

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)