### PR TITLE
Sort issues and pull requests oldest to newest

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -300,7 +300,7 @@ fn fetch_issues(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Vec
         Err(_) => return Vec::new(),
     };
 
-    issues
+    let mut cards: Vec<Card> = issues
         .into_iter()
         .map(|issue| {
             let number = issue["number"].as_u64().unwrap_or(0);
@@ -347,7 +347,10 @@ fn fetch_issues(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Vec
                 is_draft: None,
             }
         })
-        .collect()
+        .collect();
+    // Reverse to show oldest first (gh returns newest first)
+    cards.reverse();
+    cards
 }
 
 fn fetch_prs(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Vec<Card> {
@@ -380,7 +383,8 @@ fn fetch_prs(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Vec<Ca
         Err(_) => return Vec::new(),
     };
 
-    prs.into_iter()
+    let mut cards: Vec<Card> = prs
+        .into_iter()
         .map(|pr| {
             let number = pr["number"].as_u64().unwrap_or(0);
             let title = pr["title"].as_str().unwrap_or("").to_string();
@@ -423,7 +427,10 @@ fn fetch_prs(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Vec<Ca
                 is_draft: Some(is_draft),
             }
         })
-        .collect()
+        .collect();
+    // Reverse to show oldest first (gh returns newest first)
+    cards.reverse();
+    cards
 }
 
 fn create_issue(repo: &str, title: &str, body: &str) -> std::result::Result<u64, String> {


### PR DESCRIPTION
## Summary
- Reverse the ordering of issues and pull requests so they display oldest to newest, consistent with the other columns (worktrees, sessions)
- The GitHub CLI returns results newest first by default; this change reverses both the issues and PRs lists after fetching

Closes #31

## Test plan
- [ ] Launch the app and verify issues are listed oldest (lowest number) first
- [ ] Verify pull requests are listed oldest first
- [ ] Toggle state/assignee filters and confirm ordering remains oldest-first after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)