### PR TITLE
Add verify command to launch cargo run in Alacritty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1531,6 +1531,34 @@ fn main() -> Result<()> {
                                         }
                                     }
                                 }
+                                KeyCode::Char('v') if app.active_section == 1 => {
+                                    if let Some(card) = app.worktrees.get(app.selected_card[1]) {
+                                        let worktree_path = card.description.clone();
+                                        let result = Command::new("alacritty")
+                                            .args([
+                                                "--working-directory",
+                                                &worktree_path,
+                                                "-e",
+                                                "cargo",
+                                                "run",
+                                            ])
+                                            .spawn();
+                                        match result {
+                                            Ok(_) => {
+                                                app.status_message = Some(format!(
+                                                    "Launched cargo run in Alacritty for '{}'",
+                                                    card.title
+                                                ));
+                                            }
+                                            Err(e) => {
+                                                app.status_message = Some(format!(
+                                                    "Failed to launch Alacritty: {}",
+                                                    e
+                                                ));
+                                            }
+                                        }
+                                    }
+                                }
                                 // PR actions: 'o' to open in browser, 'r' to mark ready
                                 KeyCode::Char('o') if app.active_section == 3 => {
                                     if let Some(card) = app.pull_requests.get(app.selected_card[3])
@@ -2419,6 +2447,8 @@ fn ui(frame: &mut Frame, app: &App) {
                 area_spans.push(Span::styled(" Assigned to me ", desc_style));
             }
             1 => {
+                area_spans.push(Span::styled(" v ", key_accent));
+                area_spans.push(Span::styled(" Verify (cargo run) ", desc_style));
                 area_spans.push(Span::styled(" d ", key_style));
                 area_spans.push(Span::styled(" Remove worktree ", desc_style));
             }


### PR DESCRIPTION
## Summary
- Adds a `v` keybinding in the **Worktrees** column that opens a new Alacritty terminal window in the worktree directory and runs `cargo run`
- Displays a status message confirming the launch or showing an error if Alacritty is unavailable
- Updates the bottom legend bar to show the new `v` shortcut

## Why
Users need a quick way to verify code changes in a worktree by running the app, without leaving the TUI or manually navigating to the directory.

Closes #37

## Test plan
- [ ] Select a worktree and press `v` — verify that an Alacritty window opens in the correct directory running `cargo run`
- [ ] Confirm the status bar shows a success message after launching
- [ ] Verify the legend bar shows `v Verify (cargo run)` when the Worktrees column is active
- [ ] Test error handling when Alacritty is not installed — status bar should show an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)