### PR TITLE
Add h/j/k/l vim keybindings for board navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -276,10 +276,10 @@ fn main() -> Result<()> {
                                 KeyCode::Enter => {
                                     app.enter_repo_select();
                                 }
-                                KeyCode::Tab => {
+                                KeyCode::Tab | KeyCode::Char('l') => {
                                     app.active_section = (app.active_section + 1) % 4;
                                 }
-                                KeyCode::BackTab => {
+                                KeyCode::BackTab | KeyCode::Char('h') => {
                                     app.active_section = (app.active_section + 3) % 4;
                                 }
                                 KeyCode::Char('R') => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -204,7 +204,7 @@ pub fn ui_repo_select(frame: &mut Frame, state: &RepoSelectState) {
             let hint_idx = 3 + visible_count;
             if hint_idx < chunks.len() {
                 let hint = Paragraph::new(Line::from(vec![Span::styled(
-                    "↑/↓ navigate  Enter select  Esc back",
+                    "j/k ↑/↓ navigate  Enter select  Esc back",
                     Style::default().fg(Color::DarkGray),
                 )]));
                 frame.render_widget(hint, chunks[hint_idx]);
@@ -327,9 +327,9 @@ pub fn ui(frame: &mut Frame, app: &App) {
             vec![
                 Span::styled(" q/Esc ", key_style),
                 Span::styled(" Quit ", desc_style),
-                Span::styled(" Tab/S-Tab ", key_style),
+                Span::styled(" h/l Tab/S-Tab ", key_style),
                 Span::styled(" Switch column ", desc_style),
-                Span::styled(" ↑/↓ ", key_style),
+                Span::styled(" j/k ↑/↓ ", key_style),
                 Span::styled(" Navigate ", desc_style),
                 Span::styled(" / ", key_style),
                 Span::styled(" Filter ", desc_style),


### PR DESCRIPTION
## Summary
- Add `h` and `l` keys for navigating left/right across board columns (alongside existing Tab/Shift-Tab)
- `j` and `k` already worked for up/down navigation in Normal mode; updated help text to make this discoverable
- Updated help bar on the board screen and repo select hint to show all vim-style keybindings

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (6/6)
- [x] `cargo clippy` clean (pre-existing warnings only)
- [ ] Manual: verify `h`/`l` switch columns left/right on board screen
- [ ] Manual: verify `j`/`k` still navigate up/down in lists
- [ ] Manual: verify Tab/Shift-Tab and arrow keys still work as before

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)