### PR TITLE
Add configurable per-repo verify command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,8 @@ use crate::git::{cleanup_merged_worktrees, fetch_worktrees};
 use crate::github::{fetch_issues, fetch_prs};
 use crate::hooks::ensure_hook_script;
 use crate::models::{
-    AssigneeFilter, Card, ConfirmModal, IssueModal, IssueSubmitResult, Mode, RepoSelectState,
-    Screen, SessionStates, StateFilter,
+    AssigneeFilter, Card, ConfigEditState, ConfirmModal, IssueModal, IssueSubmitResult, Mode,
+    RepoSelectState, Screen, SessionStates, StateFilter,
 };
 use crate::session::fetch_sessions;
 
@@ -36,6 +36,7 @@ pub struct App {
     pub issue_submit_rx: Option<mpsc::Receiver<IssueSubmitResult>>,
     pub spinner_tick: usize,
     pub dependencies: Vec<Dependency>,
+    pub config_edit: Option<ConfigEditState>,
 }
 
 impl App {
@@ -67,6 +68,7 @@ impl App {
             issue_submit_rx: None,
             spinner_tick: 0,
             dependencies: Vec::new(),
+            config_edit: None,
         }
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -116,6 +116,7 @@ pub enum Mode {
     Filtering { query: String },
     CreatingIssue,
     Confirming,
+    EditingVerifyCommand { input: String },
 }
 
 #[derive(PartialEq)]
@@ -123,6 +124,17 @@ pub enum Screen {
     RepoSelect,
     Board,
     Dependencies,
+    Configuration,
+}
+
+pub struct ConfigEditState {
+    pub verify_command: String,
+}
+
+impl ConfigEditState {
+    pub fn new(verify_command: String) -> Self {
+        Self { verify_command }
+    }
 }
 
 #[derive(PartialEq)]


### PR DESCRIPTION
## Summary
- Verify command is now configurable per repository instead of hardcoded to `cargo run`
- When pressing `v` on a worktree with no configured command, a prompt asks the user to enter one, then saves it and runs it immediately
- New Configuration screen (`C` key from the board) allows editing the verify command at any time
- Configuration persists in `~/.config/roctopai/config.json` alongside the existing repo setting, making it shareable

## Changes
- **config.rs**: Extended `Config` struct with `verify_commands` HashMap (repo -> command), added `get_verify_command`, `set_verify_command`, and `save_full_config` helpers. Existing config files are backwards-compatible via `#[serde(default)]`
- **models.rs**: Added `Mode::EditingVerifyCommand` for the inline prompt, `Screen::Configuration` for the config page, and `ConfigEditState` struct
- **app.rs**: Added `config_edit` field to `App` struct
- **main.rs**: Updated `v` keybinding to use configured command (or prompt if unset), added `C` keybinding for config screen, added key handling for both new mode and screen
- **ui.rs**: Added verify command prompt modal, configuration screen with editable fields and config file path display, updated hint text

## Test plan
- [ ] Press `v` on a worktree with no verify command configured — should show prompt
- [ ] Enter a command (e.g. `cargo run`) and press Enter — should save and launch in Alacritty
- [ ] Press `v` again — should use the saved command without prompting
- [ ] Press `C` to open config screen, edit the command, Ctrl+S to save
- [ ] Verify `~/.config/roctopai/config.json` contains the verify command
- [ ] Switch repos and verify each repo has its own verify command
- [ ] Clear the verify command field in config and save — should remove it

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)