### PR TITLE
Add configurable editor command for worktrees

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ pub struct Config {
     pub repo: String,
     #[serde(default)]
     pub verify_commands: HashMap<String, String>,
+    #[serde(default)]
+    pub editor_commands: HashMap<String, String>,
 }
 
 pub fn config_path() -> PathBuf {
@@ -26,8 +28,16 @@ pub fn load_config() -> Option<Config> {
 }
 
 pub fn save_config(repo: &str) -> Result<()> {
-    // Load existing config to preserve verify_commands
-    let verify_commands = load_config().map(|c| c.verify_commands).unwrap_or_default();
+    // Load existing config to preserve verify_commands and editor_commands
+    let existing = load_config();
+    let verify_commands = existing
+        .as_ref()
+        .map(|c| c.verify_commands.clone())
+        .unwrap_or_default();
+    let editor_commands = existing
+        .as_ref()
+        .map(|c| c.editor_commands.clone())
+        .unwrap_or_default();
     let path = config_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -35,6 +45,7 @@ pub fn save_config(repo: &str) -> Result<()> {
     let config = Config {
         repo: repo.to_string(),
         verify_commands,
+        editor_commands,
     };
     fs::write(path, serde_json::to_string_pretty(&config)?)?;
     Ok(())
@@ -54,10 +65,28 @@ pub fn get_verify_command(repo: &str) -> Option<String> {
     config.verify_commands.get(repo).cloned()
 }
 
+pub fn get_editor_command(repo: &str) -> Option<String> {
+    let config = load_config()?;
+    config.editor_commands.get(repo).cloned()
+}
+
+pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {
+    let mut config = load_config().unwrap_or(Config {
+        repo: repo.to_string(),
+        verify_commands: HashMap::new(),
+        editor_commands: HashMap::new(),
+    });
+    config
+        .editor_commands
+        .insert(repo.to_string(), command.to_string());
+    save_full_config(&config)
+}
+
 pub fn set_verify_command(repo: &str, command: &str) -> Result<()> {
     let mut config = load_config().unwrap_or(Config {
         repo: repo.to_string(),
         verify_commands: HashMap::new(),
+        editor_commands: HashMap::new(),
     });
     config
         .verify_commands

--- a/src/models.rs
+++ b/src/models.rs
@@ -117,6 +117,7 @@ pub enum Mode {
     CreatingIssue,
     Confirming,
     EditingVerifyCommand { input: String },
+    EditingEditorCommand { input: String },
 }
 
 #[derive(PartialEq)]
@@ -129,11 +130,17 @@ pub enum Screen {
 
 pub struct ConfigEditState {
     pub verify_command: String,
+    pub editor_command: String,
+    pub active_field: usize, // 0 = verify, 1 = editor
 }
 
 impl ConfigEditState {
-    pub fn new(verify_command: String) -> Self {
-        Self { verify_command }
+    pub fn new(verify_command: String, editor_command: String) -> Self {
+        Self {
+            verify_command,
+            editor_command,
+            active_field: 0,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `e` keybinding in the Worktrees column to open a worktree in a configurable editor (launched via Alacritty)
- Prompts for the editor command the first time it is used on a repo, then persists the choice per-repo in the config file
- Adds editor command field to the Configuration screen (`C`) alongside the existing verify command, with `Tab` to switch between fields

## Changes
- **config.rs**: Added `editor_commands` HashMap to `Config`, plus `get_editor_command` and `set_editor_command` helpers
- **models.rs**: Added `EditingEditorCommand` mode variant; extended `ConfigEditState` with `editor_command` and `active_field`
- **main.rs**: Added `e` keybinding handler for worktrees, `EditingEditorCommand` mode input handling, updated Configuration screen to save/edit both commands
- **ui.rs**: Added editor prompt overlay, `e` key to worktree legend, two-field Configuration screen with active field highlighting

## Test plan
- [ ] Press `e` on a worktree with no editor configured — should show prompt
- [ ] Enter an editor command (e.g. `nvim`) — should save and launch in Alacritty
- [ ] Press `e` again — should launch directly without prompting
- [ ] Press `C` to open Configuration — should show both Verify and Editor fields with Tab switching
- [ ] Save configuration with Ctrl+S — both commands should persist
- [ ] Clear editor command and save — should prompt again on next `e` press

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)