### PR TITLE
Remove neovim pane from sessions, keep only Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Built with Rust and [Ratatui](https://github.com/ratatui/ratatui).
 
 ## What it does
 
-Roctopai gives you a kanban-style board in your terminal with four columns: **Issues**, **Worktrees**, **Sessions**, and **Pull Requests**. Select a GitHub repo, browse its issues, and spin up a git worktree with a tmux session where Claude works on the issue autonomously — with neovim open alongside it.
+Roctopai gives you a kanban-style board in your terminal with four columns: **Issues**, **Worktrees**, **Sessions**, and **Pull Requests**. Select a GitHub repo, browse its issues, and spin up a git worktree with a tmux session where Claude works on the issue autonomously.
 
 ### Features
 
 - **Repository selection** — search by GitHub org or user with fuzzy filtering; last selection is saved
 - **Issue management** — create, close, and browse issues with word-wrapping in the issue body
 - **Worktree lifecycle** — create isolated worktrees per issue, auto-cleanup when PRs are merged
-- **Claude AI sessions** — auto-launch Claude in a tmux split pane with the issue context as a prompt
+- **Claude AI sessions** — auto-launch Claude in a tmux session with the issue context as a prompt
 - **Pull request actions** — mark draft PRs as ready, merge with one key, revert merged PRs
 - **Real-time session status** — Unix socket listens for Claude hook events to show working/idle/waiting state
 - **Filtering** — toggle open/closed state and assigned-to-me on issues and pull requests; fuzzy search across all columns
@@ -27,7 +27,6 @@ Roctopai gives you a kanban-style board in your terminal with four columns: **Is
 - [gh](https://cli.github.com/) (GitHub CLI, authenticated)
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux)
-- [neovim](https://neovim.io/)
 - [claude](https://claude.ai/claude-code) (Claude Code CLI)
 
 ## Install
@@ -106,16 +105,16 @@ On first launch you'll be prompted to enter a GitHub user or org. Pick a repo an
 Pressing `w` on an issue (or `n` to create a new one):
 
 1. Creates a git worktree at `../<repo>-issue-<number>` on branch `issue-<number>`
-2. Opens a tmux session with neovim on the left and Claude on the right
+2. Opens a tmux session with Claude running in a single pane
 3. Claude receives the issue title and body as a prompt and begins working
 4. A hook script reports Claude's status back via Unix socket
 
 ```
-┌──────────────┬──────────────┐
-│              │              │
-│    neovim    │  claude -p   │
-│              │              │
-└──────────────┴──────────────┘
+┌─────────────────────────────┐
+│                             │
+│          claude -p          │
+│                             │
+└─────────────────────────────┘
 ```
 
 Attach to a session from the board by pressing `a` in the Sessions column, or from the terminal with `tmux attach -t issue-<number>`.


### PR DESCRIPTION
## Summary

- Removed the neovim pane from tmux sessions so only Claude runs in a single full-width pane
- Updated pane target index from `.1` to `.0` in both session creation and status monitoring
- Updated README to reflect the new single-pane layout and removed neovim from prerequisites

Closes #56

## Test plan

- [ ] Create a new worktree+session via `w` key and verify only Claude launches (no neovim split)
- [ ] Verify session status detection still works (working/idle/permission states)
- [ ] Attach to a session via `a` and confirm the single-pane layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)