### PR TITLE
Add configurable PR ready mode

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -131,14 +131,16 @@ pub enum Screen {
 pub struct ConfigEditState {
     pub verify_command: String,
     pub editor_command: String,
-    pub active_field: usize, // 0 = verify, 1 = editor
+    pub pr_ready: bool,
+    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready
 }
 
 impl ConfigEditState {
-    pub fn new(verify_command: String, editor_command: String) -> Self {
+    pub fn new(verify_command: String, editor_command: String, pr_ready: bool) -> Self {
         Self {
             verify_command,
             editor_command,
+            pr_ready,
             active_field: 0,
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -113,6 +113,7 @@ pub fn create_worktree_and_session(
     title: &str,
     body: &str,
     hook_script: Option<&str>,
+    pr_ready: bool,
 ) -> std::result::Result<(), String> {
     let repo_name = get_repo_name(repo);
     let branch = format!("issue-{}", number);
@@ -181,9 +182,15 @@ pub fn create_worktree_and_session(
             .join(" ")
     };
 
+    let pr_instruction = if pr_ready {
+        "open a pull request"
+    } else {
+        "open a draft pull request"
+    };
+
     let prompt = format!(
-        "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and open a draft pull request with a clear title and description that explains what was changed and why. Reference the issue with 'Closes #{}' in the PR body. Use '--assignee @me' when creating the pull request to auto-assign it.",
-        number, repo, title, body_clean, number
+        "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and {} with a clear title and description that explains what was changed and why. Reference the issue with 'Closes #{}' in the PR body. Use '--assignee @me' when creating the pull request to auto-assign it.",
+        number, repo, title, body_clean, pr_instruction, number
     );
 
     // Write prompt to a temp file for safe shell expansion

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1138,6 +1138,9 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 Constraint::Length(1), // editor label
                 Constraint::Length(3), // editor input
                 Constraint::Length(1), // spacing
+                Constraint::Length(1), // pr ready label
+                Constraint::Length(1), // pr ready toggle
+                Constraint::Length(1), // spacing
                 Constraint::Length(1), // config file path
                 Constraint::Min(0),
             ])
@@ -1145,6 +1148,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
 
         let verify_active = config_edit.active_field == 0;
         let editor_active = config_edit.active_field == 1;
+        let pr_ready_active = config_edit.active_field == 2;
 
         // Verify command field
         let verify_label = Paragraph::new(Line::from(vec![Span::styled(
@@ -1218,6 +1222,43 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
         let editor_text = Paragraph::new(Line::from(editor_spans)).block(editor_block);
         frame.render_widget(editor_text, chunks[4]);
 
+        // PR Ready toggle field
+        let pr_ready_label = Paragraph::new(Line::from(vec![Span::styled(
+            "Open PRs as Ready (not draft)",
+            Style::default()
+                .fg(if pr_ready_active {
+                    Color::Cyan
+                } else {
+                    Color::Gray
+                })
+                .add_modifier(Modifier::BOLD),
+        )]));
+        frame.render_widget(pr_ready_label, chunks[6]);
+
+        let checkbox = if config_edit.pr_ready { "[x]" } else { "[ ]" };
+        let toggle_color = if pr_ready_active {
+            Color::White
+        } else {
+            Color::DarkGray
+        };
+        let pr_ready_text = Paragraph::new(Line::from(vec![
+            Span::styled(
+                checkbox,
+                Style::default()
+                    .fg(toggle_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                if config_edit.pr_ready {
+                    "  Enabled — PRs will be opened as ready"
+                } else {
+                    "  Disabled — PRs will be opened as draft"
+                },
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+        frame.render_widget(pr_ready_text, chunks[7]);
+
         let path_label = Paragraph::new(Line::from(vec![
             Span::styled("Config file: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
@@ -1225,7 +1266,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 Style::default().fg(Color::Gray),
             ),
         ]));
-        frame.render_widget(path_label, chunks[6]);
+        frame.render_widget(path_label, chunks[9]);
     }
 
     // Bottom hint bar


### PR DESCRIPTION
## Summary
- PRs default to opening as **drafts** (existing behavior preserved)
- Adds a new per-repo **"Open PRs as Ready"** toggle in the Configuration screen (`C` key)
- The setting is stored in `config.json` under `pr_ready` and passed to the Claude prompt when creating worktree sessions
- Toggle uses `Space`/`Enter` to flip, with visual checkbox feedback

## Changes
- **config.rs**: Added `pr_ready` HashMap field to `Config`, plus `get_pr_ready()` helper
- **models.rs**: Added `pr_ready` bool to `ConfigEditState`, updated constructor
- **session.rs**: `create_worktree_and_session` accepts `pr_ready` param; prompt conditionally says "open a pull request" vs "open a draft pull request"
- **main.rs**: Wired up config loading/saving, Tab cycles through 3 fields, Space/Enter toggles the checkbox
- **ui.rs**: Renders the new toggle field with checkbox and status text

## Test plan
- [ ] Open Configuration screen (`C`), verify new "Open PRs as Ready" toggle appears
- [ ] Toggle with Space/Enter, save with Ctrl+S, verify persisted in `~/.config/roctopai/config.json`
- [ ] Create a worktree session with toggle off — Claude prompt should say "draft pull request"
- [ ] Create a worktree session with toggle on — Claude prompt should say "pull request" (no draft)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)