### PR TITLE
Add configurable Claude CLI tmux command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub editor_commands: HashMap<String, String>,
     #[serde(default)]
     pub pr_ready: HashMap<String, bool>,
+    #[serde(default)]
+    pub claude_commands: HashMap<String, String>,
 }
 
 pub fn config_path() -> PathBuf {
@@ -48,11 +50,16 @@ pub fn save_config(repo: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
+    let claude_commands = existing
+        .as_ref()
+        .map(|c| c.claude_commands.clone())
+        .unwrap_or_default();
     let config = Config {
         repo: repo.to_string(),
         verify_commands,
         editor_commands,
         pr_ready,
+        claude_commands,
     };
     fs::write(path, serde_json::to_string_pretty(&config)?)?;
     Ok(())
@@ -83,6 +90,7 @@ pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {
         verify_commands: HashMap::new(),
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
+        claude_commands: HashMap::new(),
     });
     config
         .editor_commands
@@ -96,6 +104,7 @@ pub fn set_verify_command(repo: &str, command: &str) -> Result<()> {
         verify_commands: HashMap::new(),
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
+        claude_commands: HashMap::new(),
     });
     config
         .verify_commands
@@ -107,4 +116,9 @@ pub fn get_pr_ready(repo: &str) -> bool {
     load_config()
         .and_then(|c| c.pr_ready.get(repo).copied())
         .unwrap_or(false)
+}
+
+pub fn get_claude_command(repo: &str) -> Option<String> {
+    let config = load_config()?;
+    config.claude_commands.get(repo).cloned()
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -132,15 +132,22 @@ pub struct ConfigEditState {
     pub verify_command: String,
     pub editor_command: String,
     pub pr_ready: bool,
-    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready
+    pub claude_command: String,
+    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = claude_command
 }
 
 impl ConfigEditState {
-    pub fn new(verify_command: String, editor_command: String, pr_ready: bool) -> Self {
+    pub fn new(
+        verify_command: String,
+        editor_command: String,
+        pr_ready: bool,
+        claude_command: String,
+    ) -> Self {
         Self {
             verify_command,
             editor_command,
             pr_ready,
+            claude_command,
             active_field: 0,
         }
     }


### PR DESCRIPTION
## Summary
- The Claude command sent to tmux sessions is now configurable per-repo via the Configuration panel (`C` key)
- Users can customize the command using template fields like `{prompt_file}`, `{issue_number}`, `{repo}`, `{title}`, `{body}`, `{branch}`, and `{worktree_path}`
- Available template fields are listed in the configuration panel for easy reference
- When no custom command is configured, the default `claude "$(cat '{prompt_file}')" --allowedTools Read,Edit,Bash` is used

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (6 tests)
- [x] `cargo clippy` passes (no new warnings)
- [ ] Open Configuration panel (`C`) and verify the new "Claude Command" field appears
- [ ] Verify template fields are listed below the command input
- [ ] Verify default command is shown as placeholder when field is empty
- [ ] Save a custom command and verify it persists in `config.json`
- [ ] Create a worktree session and verify the custom command is used

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)