### PR TITLE
Make editor/verify commands configurable without assuming Alacritty

### DIFF
--- a/src/deps.rs
+++ b/src/deps.rs
@@ -26,12 +26,6 @@ pub fn check_dependencies() -> Vec<Dependency> {
             "Used by hook script for socket communication",
             true,
         ),
-        check_dep(
-            "alacritty",
-            "alacritty",
-            "Terminal emulator for cargo run (optional)",
-            false,
-        ),
     ]
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -123,6 +123,18 @@ pub const TEMPLATE_FIELDS: &[(&str, &str)] = &[
     ("{worktree_path}", "Path to the git worktree"),
 ];
 
+/// Default editor command template. Users can override this entirely.
+pub const DEFAULT_EDITOR_COMMAND: &str = "alacritty --working-directory {directory} -e nvim";
+
+/// Available template fields for editor and verify command configuration.
+pub const EDITOR_TEMPLATE_FIELDS: &[(&str, &str)] =
+    &[("{directory}", "Path to the worktree directory")];
+
+/// Expand template fields in an editor or verify command string.
+pub fn expand_editor_command(template: &str, directory: &str) -> String {
+    template.replace("{directory}", directory)
+}
+
 /// Expand template fields in a command string.
 #[allow(clippy::too_many_arguments)]
 fn expand_template(


### PR DESCRIPTION
## Summary
- Removed hardcoded Alacritty terminal wrapping from editor and verify commands
- Commands are now fully user-configurable shell commands executed via `sh -c`
- Added `{directory}` template field that expands to the worktree path
- Configuration UI shows default command and available template fields for all command types
- Removed Alacritty from the dependency check list since any terminal can now be used

## Details

Previously, editor and verify commands only stored the program name (e.g., `nvim`) and always wrapped it in `alacritty --working-directory <path> -e <program>`. This forced users to have Alacritty installed.

Now users configure the entire command, using `{directory}` as a placeholder for the worktree path. For example:
- `alacritty --working-directory {directory} -e nvim` (previous default behavior)
- `kitty -d {directory} nvim`
- `code {directory}`
- `wezterm start --cwd {directory} -- nvim`

The default shown in the configuration screen is `alacritty --working-directory {directory} -e nvim` to match previous behavior.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)