### PR TITLE
Update prompt_file description to include template contents

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -114,7 +114,10 @@ pub const DEFAULT_CLAUDE_COMMAND: &str =
 /// Available template fields for the claude command configuration.
 /// Each tuple is (field_name, description).
 pub const TEMPLATE_FIELDS: &[(&str, &str)] = &[
-    ("{prompt_file}", "Path to temp file containing the prompt"),
+    (
+        "{prompt_file}",
+        "Path to temp file containing the prompt (issue number, repo, title, body, and instructions to implement a fix, commit, and open a PR)",
+    ),
     ("{issue_number}", "GitHub issue number"),
     ("{repo}", "Full repo name (owner/repo)"),
     ("{title}", "Issue title"),


### PR DESCRIPTION
## Summary
- Updated the `{prompt_file}` template field description in the configuration UI to describe what the prompt file actually contains (issue number, repo, title, body, and instructions to implement, commit, and open a PR)
- Previously the description only said "Path to temp file containing the prompt" which didn't help users understand what they'd get when using this template field

## Test plan
- [ ] Open the configuration screen (`C` key) and verify the `{prompt_file}` field description is more informative
- [ ] Verify the app compiles with `cargo check`

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)