### PR TITLE
Change legend text to be tool-agnostic

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -529,7 +529,7 @@ pub fn ui(frame: &mut Frame, app: &App) {
         match app.active_section {
             0 => {
                 area_spans.push(Span::styled(" w ", key_accent));
-                area_spans.push(Span::styled(" Worktree+Claude ", desc_style));
+                area_spans.push(Span::styled(" Worktree+Session ", desc_style));
                 area_spans.push(Span::styled(" d ", key_style));
                 area_spans.push(Span::styled(" Close issue ", desc_style));
                 area_spans.push(Span::styled(" s ", key_style));


### PR DESCRIPTION
## Summary
- Changed the Issues section legend text from "Worktree+Claude" to "Worktree+Session" since the session tool may not always be Claude

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)