### PR TITLE
Add arrow key navigation to text input fields

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -180,7 +180,7 @@ impl App {
             String::new()
         };
         self.repo_select = RepoSelectState::new();
-        self.repo_select.input = owner;
+        self.repo_select.input = crate::models::TextInput::from(owner);
         self.screen = Screen::RepoSelect;
     }
 }


### PR DESCRIPTION
## Summary
- Introduces a `TextInput` struct with cursor position tracking, replacing plain `String` fields for all text inputs
- Enables **Left/Right arrow keys**, **Home**, and **End** to move the cursor within any text field
- Applies to all input contexts: configuration screen, issue creation modal, repo selection, filter queries, and command prompts

## What was wrong
Arrow keys did not work in text input fields. All text inputs used `String::push(c)` and `String::pop()`, which only allowed appending/removing characters at the end. There was no cursor position tracking, so users couldn't go back to fix typos mid-text.

## What changed
- **`models.rs`**: Added `TextInput` struct with `text` and `cursor` fields, plus methods for `insert`, `delete_back`, `move_left`, `move_right`, `move_home`, `move_end`. Updated `ConfigEditState`, `IssueModal`, `RepoSelectState`, and `Mode` variants to use `TextInput` instead of `String`.
- **`main.rs`**: Added `KeyCode::Left`, `KeyCode::Right`, `KeyCode::Home`, `KeyCode::End` handlers in all input modes. Replaced `push(c)`/`pop()` with `TextInput` methods.
- **`ui.rs`**: Added `text_input_spans()` helper to render cursor at the correct position. Updated all text field rendering to show a block cursor at the current position. Consolidated `ui_verify_prompt` and `ui_editor_prompt` into a unified `ui_text_prompt`.
- **`app.rs`**: Updated `enter_repo_select` to use `TextInput::from()`.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] All 6 existing tests pass
- [ ] Manual testing: verify arrow keys move cursor in config fields, issue title/body, repo input, and filter queries

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)