### PR TITLE
Add command shortcut templates for configuration defaults

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -127,15 +127,48 @@ pub const TEMPLATE_FIELDS: &[(&str, &str)] = &[
 ];
 
 /// Default editor command template. Users can override this entirely.
-pub const DEFAULT_EDITOR_COMMAND: &str = "alacritty --working-directory {directory} -e nvim";
+pub const DEFAULT_EDITOR_COMMAND: &str = "{alacritty} nvim";
 
 /// Available template fields for editor and verify command configuration.
 pub const EDITOR_TEMPLATE_FIELDS: &[(&str, &str)] =
     &[("{directory}", "Path to the worktree directory")];
 
+/// Shortcut templates that expand to common terminal emulator prefixes.
+/// Each shortcut expands to include `{directory}` which is then resolved
+/// in a second pass.
+pub const COMMAND_SHORTCUTS: &[(&str, &str, &str)] = &[
+    (
+        "{alacritty}",
+        "alacritty --working-directory {directory} -e",
+        "Alacritty terminal with working directory",
+    ),
+    (
+        "{kitty}",
+        "kitty -d {directory} -e",
+        "Kitty terminal with working directory",
+    ),
+    (
+        "{wezterm}",
+        "wezterm start --cwd {directory} --",
+        "WezTerm terminal with working directory",
+    ),
+];
+
+/// Expand shortcut templates in a command string.
+fn expand_shortcuts(template: &str) -> String {
+    let mut result = template.to_string();
+    for (shortcut, expansion, _) in COMMAND_SHORTCUTS {
+        result = result.replace(shortcut, expansion);
+    }
+    result
+}
+
 /// Expand template fields in an editor or verify command string.
+/// Shortcut templates (e.g. `{alacritty}`) are expanded first, then
+/// `{directory}` is resolved.
 pub fn expand_editor_command(template: &str, directory: &str) -> String {
-    template.replace("{directory}", directory)
+    let expanded = expand_shortcuts(template);
+    expanded.replace("{directory}", directory)
 }
 
 /// Expand template fields in a command string.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,7 +17,8 @@ use crate::models::{
     TextInput, REFRESH_INTERVAL,
 };
 use crate::session::{
-    DEFAULT_CLAUDE_COMMAND, DEFAULT_EDITOR_COMMAND, EDITOR_TEMPLATE_FIELDS, TEMPLATE_FIELDS,
+    COMMAND_SHORTCUTS, DEFAULT_CLAUDE_COMMAND, DEFAULT_EDITOR_COMMAND, EDITOR_TEMPLATE_FIELDS,
+    TEMPLATE_FIELDS,
 };
 
 /// Build spans for a TextInput showing the cursor at the correct position.
@@ -1334,6 +1335,24 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
             lines.push(Line::from(vec![
                 Span::styled(format!("    {} ", field), Style::default().fg(Color::Cyan)),
                 Span::styled(format!("- {}", desc), Style::default().fg(Color::DarkGray)),
+            ]));
+        }
+        // Command shortcuts
+        lines.push(Line::from(vec![Span::styled(
+            "  Shortcuts (expand {directory} automatically):",
+            Style::default().fg(Color::Gray),
+        )]));
+        for (shortcut, expansion, desc) in COMMAND_SHORTCUTS {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("    {} ", shortcut),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(format!("- {} ", desc), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("({})", expansion),
+                    Style::default().fg(Color::DarkGray),
+                ),
             ]));
         }
         // Claude template fields


### PR DESCRIPTION
## Summary
- Add shortcut templates (`{alacritty}`, `{kitty}`, `{wezterm}`) for editor and verify command configuration
- Shortcuts expand to the full terminal emulator command including `{directory}`, so users can type `{alacritty} nvim` instead of `alacritty --working-directory {directory} -e nvim`
- Shortcuts are expanded first, then `{directory}` is resolved in a second pass
- Default editor command updated to use `{alacritty} nvim` to demonstrate the feature
- Available shortcuts are displayed in the configuration UI under the template fields section

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 6 tests pass
- [x] `cargo clippy` — no new warnings
- [ ] Verify shortcut expansion works in the config UI by setting editor command to `{alacritty} nvim` and launching an editor on a worktree
- [ ] Verify `{kitty}` and `{wezterm}` shortcuts expand correctly
- [ ] Verify shortcuts are displayed in the configuration screen

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)