### PR TITLE
Add Message Center with toggle and expand keybindings

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -6,8 +6,10 @@ use ratatui::style::Color;
 
 pub const SOCKET_PATH: &str = "/tmp/roctopai-events.sock";
 pub const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+pub const MAX_MESSAGES: usize = 100;
 
 pub type SessionStates = Arc<Mutex<HashMap<String, String>>>;
+pub type MessageLog = Arc<Mutex<VecDeque<String>>>;
 
 pub struct Card {
     pub id: String,


### PR DESCRIPTION
## Summary
- Adds a **Message Center** panel between the board columns and the legend bar that persistently logs all status messages and hook events
- Messages that previously only flashed briefly in the legend are now preserved in a scrollable log (capped at 100 entries)
- Hook events (Claude session status changes like working, idle, permission) are logged in blue; status messages in yellow
- `x` toggles message center visibility; `X` expands/collapses it (3 vs 10 lines)
- Uses a thread-safe `Arc<Mutex<VecDeque<String>>>` shared between the main thread and the Unix socket hook event handler

## Test plan
- [x] `cargo check` passes with no errors
- [x] `cargo clippy -- -W clippy::all` shows only pre-existing warnings
- [x] `cargo test` — all 6 tests pass
- [ ] Manual: launch app, verify message center appears below columns
- [ ] Manual: press `x` to hide/show message center
- [ ] Manual: press `X` to expand/collapse when visible
- [ ] Manual: perform actions (refresh, create worktree, etc.) and verify messages appear in the log
- [ ] Manual: trigger hook events and verify they appear in blue

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)