### PR TITLE
Add Cursor session support with generic session config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,8 +14,8 @@ pub struct Config {
     pub editor_commands: HashMap<String, String>,
     #[serde(default)]
     pub pr_ready: HashMap<String, bool>,
-    #[serde(default)]
-    pub claude_commands: HashMap<String, String>,
+    #[serde(default, alias = "claude_commands")]
+    pub session_commands: HashMap<String, String>,
 }
 
 pub fn config_path() -> PathBuf {
@@ -50,16 +50,16 @@ pub fn save_config(repo: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let claude_commands = existing
+    let session_commands = existing
         .as_ref()
-        .map(|c| c.claude_commands.clone())
+        .map(|c| c.session_commands.clone())
         .unwrap_or_default();
     let config = Config {
         repo: repo.to_string(),
         verify_commands,
         editor_commands,
         pr_ready,
-        claude_commands,
+        session_commands,
     };
     fs::write(path, serde_json::to_string_pretty(&config)?)?;
     Ok(())
@@ -90,7 +90,7 @@ pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {
         verify_commands: HashMap::new(),
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
-        claude_commands: HashMap::new(),
+        session_commands: HashMap::new(),
     });
     config
         .editor_commands
@@ -104,7 +104,7 @@ pub fn set_verify_command(repo: &str, command: &str) -> Result<()> {
         verify_commands: HashMap::new(),
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
-        claude_commands: HashMap::new(),
+        session_commands: HashMap::new(),
     });
     config
         .verify_commands
@@ -118,7 +118,7 @@ pub fn get_pr_ready(repo: &str) -> bool {
         .unwrap_or(false)
 }
 
-pub fn get_claude_command(repo: &str) -> Option<String> {
+pub fn get_session_command(repo: &str) -> Option<String> {
     let config = load_config()?;
-    config.claude_commands.get(repo).cloned()
+    config.session_commands.get(repo).cloned()
 }

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -9,24 +9,41 @@ pub struct Dependency {
 }
 
 pub fn check_dependencies() -> Vec<Dependency> {
-    vec![
+    let mut deps = vec![
         check_dep("gh", "gh", "GitHub CLI for issue/PR management", true),
         check_dep("git", "git", "Version control with worktree support", true),
         check_dep("tmux", "tmux", "Terminal multiplexer for sessions", true),
         check_dep("nvim", "nvim", "Editor launched in worktree sessions", true),
-        check_dep(
-            "claude",
-            "claude",
-            "Claude Code CLI for autonomous work",
-            true,
-        ),
-        check_dep(
-            "python3",
-            "python3",
-            "Used by hook script for socket communication",
-            true,
-        ),
-    ]
+    ];
+
+    // Require at least one AI coding assistant (claude or cursor)
+    let claude = check_dep(
+        "claude",
+        "claude",
+        "Claude Code CLI for autonomous work",
+        false,
+    );
+    let cursor = check_dep("cursor", "cursor", "Cursor CLI for autonomous work", false);
+    let either_available = claude.available || cursor.available;
+    deps.push(Dependency {
+        name: "claude/cursor",
+        description: "AI coding assistant (Claude Code or Cursor)",
+        required: true,
+        available: either_available,
+        version: if claude.available {
+            claude.version
+        } else {
+            cursor.version
+        },
+    });
+
+    deps.push(check_dep(
+        "python3",
+        "python3",
+        "Used by hook script for socket communication",
+        true,
+    ));
+    deps
 }
 
 fn check_dep(

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use crossterm::{
 
 use app::App;
 use config::{
-    get_claude_command, get_editor_command, get_pr_ready, get_verify_command, load_config,
+    get_editor_command, get_pr_ready, get_session_command, get_verify_command, load_config,
     save_config, set_editor_command, set_verify_command,
 };
 use deps::{check_dependencies, has_missing_required};
@@ -205,7 +205,7 @@ fn main() -> Result<()> {
                                 let editor_cmd =
                                     config_edit.editor_command.value().trim().to_string();
                                 let claude_cmd =
-                                    config_edit.claude_command.value().trim().to_string();
+                                    config_edit.session_command.value().trim().to_string();
                                 let repo = app.repo.clone();
 
                                 let pr_ready = config_edit.pr_ready;
@@ -231,10 +231,10 @@ fn main() -> Result<()> {
                                         config.pr_ready.remove(&repo);
                                     }
                                     if claude_cmd.is_empty() {
-                                        config.claude_commands.remove(&repo);
+                                        config.session_commands.remove(&repo);
                                     } else {
                                         config
-                                            .claude_commands
+                                            .session_commands
                                             .insert(repo.clone(), claude_cmd.clone());
                                     }
                                     let _ = config::save_full_config(&config);
@@ -247,31 +247,31 @@ fn main() -> Result<()> {
                             KeyCode::Backspace => match config_edit.active_field {
                                 0 => config_edit.verify_command.delete_back(),
                                 1 => config_edit.editor_command.delete_back(),
-                                3 => config_edit.claude_command.delete_back(),
+                                3 => config_edit.session_command.delete_back(),
                                 _ => {}
                             },
                             KeyCode::Left => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_left(),
                                 1 => config_edit.editor_command.move_left(),
-                                3 => config_edit.claude_command.move_left(),
+                                3 => config_edit.session_command.move_left(),
                                 _ => {}
                             },
                             KeyCode::Right => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_right(),
                                 1 => config_edit.editor_command.move_right(),
-                                3 => config_edit.claude_command.move_right(),
+                                3 => config_edit.session_command.move_right(),
                                 _ => {}
                             },
                             KeyCode::Home => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_home(),
                                 1 => config_edit.editor_command.move_home(),
-                                3 => config_edit.claude_command.move_home(),
+                                3 => config_edit.session_command.move_home(),
                                 _ => {}
                             },
                             KeyCode::End => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_end(),
                                 1 => config_edit.editor_command.move_end(),
-                                3 => config_edit.claude_command.move_end(),
+                                3 => config_edit.session_command.move_end(),
                                 _ => {}
                             },
                             KeyCode::Char(' ') if config_edit.active_field == 2 => {
@@ -283,7 +283,7 @@ fn main() -> Result<()> {
                             KeyCode::Char(c) => match config_edit.active_field {
                                 0 => config_edit.verify_command.insert(c),
                                 1 => config_edit.editor_command.insert(c),
-                                3 => config_edit.claude_command.insert(c),
+                                3 => config_edit.session_command.insert(c),
                                 _ => {}
                             },
                             _ => {}
@@ -483,7 +483,7 @@ fn main() -> Result<()> {
                                                     .unwrap_or_default();
                                                 let repo = app.repo.clone();
                                                 let pr_ready = get_pr_ready(&repo);
-                                                let claude_cmd = get_claude_command(&repo);
+                                                let claude_cmd = get_session_command(&repo);
                                                 match create_worktree_and_session(
                                                     &repo,
                                                     number,
@@ -620,7 +620,7 @@ fn main() -> Result<()> {
                                         get_editor_command(&app.repo).unwrap_or_default();
                                     let current_pr_ready = get_pr_ready(&app.repo);
                                     let current_claude =
-                                        get_claude_command(&app.repo).unwrap_or_default();
+                                        get_session_command(&app.repo).unwrap_or_default();
                                     app.config_edit = Some(ConfigEditState::new(
                                         current_verify,
                                         current_editor,
@@ -1051,7 +1051,7 @@ fn main() -> Result<()> {
                                             let body = modal.body.value().to_string();
                                             let repo = app.repo.clone();
                                             let hook_script = app.hook_script_path.clone();
-                                            let claude_cmd = get_claude_command(&repo);
+                                            let claude_cmd = get_session_command(&repo);
                                             let (tx, rx) = mpsc::channel();
                                             app.issue_submit_rx = Some(rx);
                                             std::thread::spawn(move || {

--- a/src/models.rs
+++ b/src/models.rs
@@ -134,8 +134,8 @@ pub struct ConfigEditState {
     pub verify_command: TextInput,
     pub editor_command: TextInput,
     pub pr_ready: bool,
-    pub claude_command: TextInput,
-    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = claude_command
+    pub session_command: TextInput,
+    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = session_command
 }
 
 impl ConfigEditState {
@@ -143,13 +143,13 @@ impl ConfigEditState {
         verify_command: String,
         editor_command: String,
         pr_ready: bool,
-        claude_command: String,
+        session_command: String,
     ) -> Self {
         Self {
             verify_command: TextInput::from(verify_command),
             editor_command: TextInput::from(editor_command),
             pr_ready,
-            claude_command: TextInput::from(claude_command),
+            session_command: TextInput::from(session_command),
             active_field: 0,
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -18,7 +18,7 @@ use crate::models::{
 };
 use crate::session::{
     COMMAND_SHORTCUTS, DEFAULT_CLAUDE_COMMAND, DEFAULT_EDITOR_COMMAND, EDITOR_TEMPLATE_FIELDS,
-    TEMPLATE_FIELDS,
+    SESSION_SHORTCUTS, TEMPLATE_FIELDS,
 };
 
 /// Build spans for a TextInput showing the cursor at the correct position.
@@ -1240,8 +1240,8 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 Constraint::Length(1), // pr ready label
                 Constraint::Length(1), // pr ready toggle
                 Constraint::Length(1), // spacing
-                Constraint::Length(1), // claude command label
-                Constraint::Length(3), // claude command input
+                Constraint::Length(1), // session command label
+                Constraint::Length(3), // session command input
                 Constraint::Length(1), // spacing
                 Constraint::Length(1), // template fields header
                 Constraint::Min(0),    // template fields list + config path
@@ -1251,7 +1251,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
         let verify_active = config_edit.active_field == 0;
         let editor_active = config_edit.active_field == 1;
         let pr_ready_active = config_edit.active_field == 2;
-        let claude_active = config_edit.active_field == 3;
+        let session_active = config_edit.active_field == 3;
 
         // Verify command field
         let verify_label = Paragraph::new(Line::from(vec![Span::styled(
@@ -1369,31 +1369,31 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
         ]));
         frame.render_widget(pr_ready_text, chunks[7]);
 
-        // Claude command field
-        let claude_label = Paragraph::new(Line::from(vec![Span::styled(
-            "Claude Command",
+        // Session command field
+        let session_label = Paragraph::new(Line::from(vec![Span::styled(
+            "Session Command",
             Style::default()
-                .fg(if claude_active {
+                .fg(if session_active {
                     Color::Cyan
                 } else {
                     Color::Gray
                 })
                 .add_modifier(Modifier::BOLD),
         )]));
-        frame.render_widget(claude_label, chunks[9]);
+        frame.render_widget(session_label, chunks[9]);
 
-        let claude_border = if claude_active {
+        let session_border = if session_active {
             Style::default()
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::DarkGray)
         };
-        let claude_block = Block::default()
+        let session_block = Block::default()
             .borders(Borders::ALL)
-            .border_style(claude_border)
+            .border_style(session_border)
             .title(" Command ");
-        let claude_spans = if config_edit.claude_command.is_empty() && !claude_active {
+        let session_spans = if config_edit.session_command.is_empty() && !session_active {
             vec![Span::styled(
                 DEFAULT_CLAUDE_COMMAND,
                 Style::default()
@@ -1402,14 +1402,14 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
             )]
         } else {
             text_input_spans(
-                &config_edit.claude_command,
+                &config_edit.session_command,
                 text_style,
                 cursor_style,
-                claude_active,
+                session_active,
             )
         };
-        let claude_text = Paragraph::new(Line::from(claude_spans)).block(claude_block);
-        frame.render_widget(claude_text, chunks[10]);
+        let session_text = Paragraph::new(Line::from(session_spans)).block(session_block);
+        frame.render_widget(session_text, chunks[10]);
 
         // Template fields header
         let fields_header = Paragraph::new(Line::from(vec![Span::styled(
@@ -1451,9 +1451,27 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 ),
             ]));
         }
-        // Claude template fields
+        // Session command shortcuts
         lines.push(Line::from(vec![Span::styled(
-            "  Claude command:",
+            "  Session command shortcuts:",
+            Style::default().fg(Color::Gray),
+        )]));
+        for (shortcut, expansion, desc) in SESSION_SHORTCUTS {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("    {} ", shortcut),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(format!("- {} ", desc), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("({})", expansion),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]));
+        }
+        // Session template fields
+        lines.push(Line::from(vec![Span::styled(
+            "  Session command fields:",
             Style::default().fg(Color::Gray),
         )]));
         for (field, desc) in TEMPLATE_FIELDS {


### PR DESCRIPTION
## Summary
- Renamed "Claude Command" to "Session Command" in the configuration UI so the label is no longer Claude-specific
- Renamed `claude_commands` config field to `session_commands` (with `serde(alias)` for backward compatibility with existing configs)
- Added `{claude}` and `{cursor}` template shortcuts for the session command field, allowing easy switching between AI assistants (e.g. just type `{cursor}` in the session command config)
- Updated health check to pass if **either** `claude` or `cursor` is installed (instead of requiring `claude`)
- Added `DEFAULT_CURSOR_COMMAND` constant alongside `DEFAULT_CLAUDE_COMMAND`
- Updated session status text from "Claude is thinking..." to "Processing..." to be assistant-agnostic

## Test plan
- [ ] Verify `cargo check` and `cargo test` pass
- [ ] Confirm the config screen shows "Session Command" instead of "Claude Command"
- [ ] Confirm `{claude}` and `{cursor}` shortcuts appear in the template fields section
- [ ] Verify health check passes with only `cursor` installed (no `claude`)
- [ ] Verify health check passes with only `claude` installed (no `cursor`)
- [ ] Verify existing configs with `claude_commands` key still load correctly via serde alias

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)