### PR TITLE
Fix cursor template command to use cursor-agent

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -112,8 +112,7 @@ pub const DEFAULT_CLAUDE_COMMAND: &str =
     "claude \"$(cat '{prompt_file}')\" --allowedTools Read,Edit,Bash";
 
 /// Default command template for Cursor sessions.
-pub const DEFAULT_CURSOR_COMMAND: &str =
-    "cursor \"$(cat '{prompt_file}')\" --allowedTools Read,Edit,Bash";
+pub const DEFAULT_CURSOR_COMMAND: &str = "cursor-agent \"$(cat '{prompt_file}')\"";
 
 /// Available template fields for the session command configuration.
 /// Each tuple is (field_name, description).


### PR DESCRIPTION
## Summary
- Fixed `DEFAULT_CURSOR_COMMAND` in `src/session.rs` to use `cursor-agent` instead of `cursor`
- The cursor template command was sending the wrong executable name

## Test plan
- [x] `cargo check` passes
- [x] All 6 tests pass

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)