### PR TITLE
Fix messages double posted in legend and messages panel

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,6 @@ pub struct App {
     pub mode: Mode,
     pub issue_modal: Option<IssueModal>,
     pub confirm_modal: Option<ConfirmModal>,
-    pub status_message: Option<String>,
     pub last_refresh: Instant,
     pub session_states: SessionStates,
     pub hook_script_path: Option<String>,
@@ -59,7 +58,6 @@ impl App {
             mode: Mode::Normal,
             issue_modal: None,
             confirm_modal: None,
-            status_message: None,
             sessions: Vec::new(),
             last_refresh: Instant::now(),
             session_states,
@@ -89,7 +87,6 @@ impl App {
 
     pub fn set_status(&mut self, msg: String) {
         self.add_message(&msg);
-        self.status_message = Some(msg);
     }
 
     pub fn section_cards(&self, section: usize) -> &[Card] {

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,8 +441,6 @@ fn main() -> Result<()> {
                             _ => {}
                         },
                         Mode::Normal => {
-                            // Clear status message on any keypress
-                            app.status_message = None;
                             match key.code {
                                 KeyCode::Char('q') | KeyCode::Esc => break,
                                 KeyCode::Enter => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -496,17 +496,6 @@ pub fn ui(frame: &mut Frame, app: &App) {
     // Top line: global actions (or mode-specific actions for non-Normal modes)
     let mut global_spans: Vec<Span> = Vec::new();
 
-    // Status message prefix
-    if let Some(msg) = &app.status_message {
-        global_spans.push(Span::styled(
-            format!(" {} ", msg),
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        ));
-        global_spans.push(Span::styled(" | ", desc_style));
-    }
-
     let global_mode_spans: Vec<Span> = match &app.mode {
         Mode::Normal => {
             vec![


### PR DESCRIPTION
## Summary
- Removed the `status_message` field from `App` and its display in the legend bar
- Messages now only appear in the Messages panel (toggled with `x`), eliminating the duplication where every status message was shown in both the legend bar and the Messages panel
- Cleaned up the keypress handler that cleared the now-removed status message

Closes #88

## Test plan
- [ ] Trigger actions that produce status messages (create issue, delete worktree, etc.)
- [ ] Verify messages appear only in the Messages panel, not duplicated in the legend bar
- [ ] Verify the legend bar still shows keybinding hints correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)