### PR TITLE
Fix slow worktree cleanup after PR merge

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -76,6 +76,7 @@ pub fn fetch_worktrees() -> Vec<Card> {
             pr_number: None,
             is_draft: None,
             is_merged: None,
+            head_branch: None,
         });
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -119,6 +119,7 @@ pub fn fetch_issues(repo: &str, state: StateFilter, assignee: AssigneeFilter) ->
                 pr_number: None,
                 is_draft: None,
                 is_merged: None,
+                head_branch: None,
             }
         })
         .collect();
@@ -201,6 +202,7 @@ pub fn fetch_prs(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Ve
                 pr_number: Some(number),
                 is_draft: Some(is_draft),
                 is_merged: Some(is_merged),
+                head_branch: Some(branch),
             }
         })
         .collect();

--- a/src/models.rs
+++ b/src/models.rs
@@ -23,6 +23,7 @@ pub struct Card {
     pub pr_number: Option<u64>,
     pub is_draft: Option<bool>,
     pub is_merged: Option<bool>,
+    pub head_branch: Option<String>,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -101,6 +102,7 @@ pub enum ConfirmAction {
     MergePr {
         number: u64,
         strategy: MergeStrategy,
+        branch: Option<String>,
     },
     RevertPr {
         number: u64,

--- a/src/session.rs
+++ b/src/session.rs
@@ -91,6 +91,7 @@ pub fn fetch_sessions(socket_states: &SessionStates) -> Vec<Card> {
                 pr_number: None,
                 is_draft: None,
                 is_merged: None,
+                head_branch: None,
             }
         })
         .collect()


### PR DESCRIPTION
## Summary
- After merging a PR, the associated worktree is now removed immediately instead of waiting for the next refresh cycle
- Previously, cleanup depended on polling GitHub's API every 30 seconds for merged branches, but GitHub's eventual consistency caused long delays before the merged state was reflected
- Added `head_branch` field to `Card` and `branch` to `MergePr` action so the branch name is available at merge time for direct worktree removal

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — all 6 tests pass
- [x] `cargo clippy` — no new warnings (2 pre-existing in ui.rs)
- [ ] Manually merge a PR from the app and verify the worktree is cleaned up immediately without delay

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)