### PR TITLE
Add indicator when main branch is behind remote

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use std::sync::mpsc;
 use std::time::Instant;
 
 use crate::deps::Dependency;
-use crate::git::{cleanup_merged_worktrees, fetch_worktrees};
+use crate::git::{cleanup_merged_worktrees, fetch_main_behind_count, fetch_worktrees};
 use crate::github::{fetch_issues, fetch_prs};
 use crate::hooks::ensure_hook_script;
 use crate::models::{
@@ -39,6 +39,7 @@ pub struct App {
     pub message_log: MessageLog,
     pub show_messages: bool,
     pub messages_expanded: bool,
+    pub main_behind_count: usize,
 }
 
 impl App {
@@ -73,6 +74,7 @@ impl App {
             message_log: message_log.clone(),
             show_messages: true,
             messages_expanded: false,
+            main_behind_count: 0,
         }
     }
 
@@ -186,6 +188,7 @@ impl App {
         }
 
         self.sessions = fetch_sessions(&self.session_states);
+        self.main_behind_count = fetch_main_behind_count();
         self.clamp_selected();
         self.last_refresh = Instant::now();
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -408,7 +408,7 @@ pub fn ui(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
         .title(" Repository ");
-    let repo_text = Paragraph::new(Line::from(vec![
+    let mut repo_spans = vec![
         Span::styled("  ", Style::default()),
         Span::styled(
             &app.repo,
@@ -416,9 +416,24 @@ pub fn ui(frame: &mut Frame, app: &App) {
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("  (Enter to change)", Style::default().fg(Color::DarkGray)),
-    ]))
-    .block(repo_block);
+    ];
+    if app.main_behind_count > 0 {
+        repo_spans.push(Span::styled(
+            format!(
+                "  main is {} commit{} behind",
+                app.main_behind_count,
+                if app.main_behind_count == 1 { "" } else { "s" }
+            ),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    repo_spans.push(Span::styled(
+        "  (Enter to change)",
+        Style::default().fg(Color::DarkGray),
+    ));
+    let repo_text = Paragraph::new(Line::from(repo_spans)).block(repo_block);
     frame.render_widget(repo_text, outer[0]);
 
     // Four columns


### PR DESCRIPTION
## Summary
- Adds a `fetch_main_behind_count()` function in `git.rs` that runs `git fetch` and checks how many commits the local main/master branch is behind `origin`
- Stores the behind count in `App` state, updated on each refresh cycle
- Displays a yellow warning in the repository top bar when behind (e.g. "main is 3 commits behind")

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes (no new warnings)
- [x] All existing tests pass
- [ ] Manual verification: pull latest on a repo where main is behind and confirm the indicator appears
- [ ] Verify indicator disappears after running `git pull` on main

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)