### PR TITLE
Auto-detect repository when launched from a git directory

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -11,6 +11,33 @@ pub fn get_repo_name(repo: &str) -> &str {
     repo.split('/').last().unwrap_or(repo)
 }
 
+/// Detect the GitHub "owner/repo" for the current working directory by
+/// asking `gh` which repository this directory belongs to.
+pub fn detect_current_repo() -> Option<String> {
+    let output = Command::new("gh")
+        .args([
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner",
+            "-q",
+            ".nameWithOwner",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let repo = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if repo.is_empty() || !repo.contains('/') {
+        return None;
+    }
+
+    Some(repo)
+}
+
 pub fn fetch_worktrees() -> Vec<Card> {
     let output = Command::new("git")
         .args(["worktree", "list", "--porcelain"])


### PR DESCRIPTION
## Summary
- When octopai is opened inside a git repository with a GitHub remote, it now automatically detects and sets the repository using `gh repo view`, skipping the manual repo selection screen
- Falls back to the existing RepoSelect flow if detection fails or the directory is not a git repo
- The detected repo is saved to config so subsequent launches also remember it

## Test plan
- [ ] Launch octopai from within a cloned GitHub repo — should skip RepoSelect and go straight to the Board
- [ ] Launch octopai from a non-git directory with no saved config — should show RepoSelect as before
- [ ] Launch octopai with an existing config — should use the saved repo (no change in behavior)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)