### PR TITLE
Use $EDITOR as default editor

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -80,8 +80,15 @@ pub fn get_verify_command(repo: &str) -> Option<String> {
 }
 
 pub fn get_editor_command(repo: &str) -> Option<String> {
-    let config = load_config()?;
-    config.editor_commands.get(repo).cloned()
+    let config = load_config();
+    let saved = config.and_then(|c| c.editor_commands.get(repo).cloned());
+    if saved.is_some() {
+        return saved;
+    }
+    // Fall back to $EDITOR environment variable
+    std::env::var("EDITOR")
+        .ok()
+        .map(|editor| format!("{editor} {{directory}}"))
 }
 
 pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1320,9 +1320,12 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
             .borders(Borders::ALL)
             .border_style(editor_border)
             .title(" Command ");
+        let editor_placeholder = std::env::var("EDITOR")
+            .map(|e| format!("{e} {{directory}}"))
+            .unwrap_or_else(|_| DEFAULT_EDITOR_COMMAND.to_string());
         let editor_spans = if config_edit.editor_command.is_empty() && !editor_active {
             vec![Span::styled(
-                DEFAULT_EDITOR_COMMAND,
+                editor_placeholder,
                 Style::default()
                     .fg(Color::DarkGray)
                     .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary
- Falls back to the `$EDITOR` environment variable when no editor command has been configured for a repository
- Updates the configuration screen placeholder to show the `$EDITOR`-based command when the variable is set
- If neither a saved editor command nor `$EDITOR` is available, the user is still prompted to configure one

## How it works
`get_editor_command()` now checks for `$EDITOR` after finding no saved config, constructing a command template like `vim {directory}` that integrates with the existing template expansion system.

Closes #102

## Test plan
- [ ] Set `$EDITOR` and launch without a saved editor command — pressing `e` should open the editor from `$EDITOR`
- [ ] Save an editor command in config — it should take priority over `$EDITOR`
- [ ] Unset `$EDITOR` with no saved config — should prompt for editor command as before
- [ ] Open config screen with `$EDITOR` set — placeholder should show `$EDITOR {directory}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)