### PR TITLE
Add terminal auto-detection for $EDITOR fallback

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -85,10 +85,8 @@ pub fn get_editor_command(repo: &str) -> Option<String> {
     if saved.is_some() {
         return saved;
     }
-    // Fall back to $EDITOR environment variable
-    std::env::var("EDITOR")
-        .ok()
-        .map(|editor| format!("{editor} {{directory}}"))
+    // Fall back to detected terminal + $EDITOR
+    crate::session::default_editor_command()
 }
 
 pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -17,8 +17,8 @@ use crate::models::{
     StateFilter, TextInput, REFRESH_INTERVAL,
 };
 use crate::session::{
-    COMMAND_SHORTCUTS, DEFAULT_CLAUDE_COMMAND, DEFAULT_EDITOR_COMMAND, EDITOR_TEMPLATE_FIELDS,
-    SESSION_SHORTCUTS, TEMPLATE_FIELDS,
+    default_editor_command, COMMAND_SHORTCUTS, DEFAULT_CLAUDE_COMMAND, DEFAULT_EDITOR_COMMAND,
+    EDITOR_TEMPLATE_FIELDS, SESSION_SHORTCUTS, TEMPLATE_FIELDS,
 };
 
 /// Build spans for a TextInput showing the cursor at the correct position.
@@ -1320,9 +1320,8 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
             .borders(Borders::ALL)
             .border_style(editor_border)
             .title(" Command ");
-        let editor_placeholder = std::env::var("EDITOR")
-            .map(|e| format!("{e} {{directory}}"))
-            .unwrap_or_else(|_| DEFAULT_EDITOR_COMMAND.to_string());
+        let editor_placeholder =
+            default_editor_command().unwrap_or_else(|| DEFAULT_EDITOR_COMMAND.to_string());
         let editor_spans = if config_edit.editor_command.is_empty() && !editor_active {
             vec![Span::styled(
                 editor_placeholder,


### PR DESCRIPTION
## Summary
- Adds terminal emulator auto-detection (`$TERMINAL` env var, then PATH probing for alacritty/kitty/wezterm) so the `$EDITOR` fallback opens in a proper terminal window
- Updates the config screen placeholder to reflect the detected terminal + editor combination
- Previously, the `$EDITOR` fallback ran the editor without a terminal emulator, which doesn't work for TUI editors (vim/nvim) since the command is spawned as a background process

## Test plan
- [ ] Set `$EDITOR=nvim` and `$TERMINAL=alacritty`, verify editor opens in Alacritty
- [ ] Unset `$TERMINAL`, have kitty on PATH, verify it's auto-detected
- [ ] Verify config screen placeholder shows the detected terminal + editor
- [ ] Verify saved per-repo editor commands still take priority over the fallback

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)