### PR TITLE
Add configurable session multiplexer (tmux/screen)

### DIFF
--- a/src/deps.rs
+++ b/src/deps.rs
@@ -12,8 +12,28 @@ pub fn check_dependencies() -> Vec<Dependency> {
     let mut deps = vec![
         check_dep("gh", "gh", "GitHub CLI for issue/PR management", true),
         check_dep("git", "git", "Version control with worktree support", true),
-        check_dep("tmux", "tmux", "Terminal multiplexer for sessions", true),
     ];
+
+    // Require at least one terminal multiplexer (tmux or screen)
+    let tmux = check_dep("tmux", "tmux", "Terminal multiplexer for sessions", false);
+    let screen = check_dep(
+        "screen",
+        "screen",
+        "Terminal multiplexer for sessions",
+        false,
+    );
+    let mux_available = tmux.available || screen.available;
+    deps.push(Dependency {
+        name: "tmux/screen",
+        description: "Terminal multiplexer (tmux or GNU Screen)",
+        required: true,
+        available: mux_available,
+        version: if tmux.available {
+            tmux.version
+        } else {
+            screen.version
+        },
+    });
 
     // Require at least one AI coding assistant (claude or cursor)
     let claude = check_dep(
@@ -51,8 +71,12 @@ fn check_dep(
     description: &'static str,
     required: bool,
 ) -> Dependency {
-    // tmux uses -V instead of --version
-    let version_flag = if command == "tmux" { "-V" } else { "--version" };
+    // tmux and screen use -V instead of --version
+    let version_flag = if command == "tmux" || command == "screen" {
+        "-V"
+    } else {
+        "--version"
+    };
 
     let (available, version) = match Command::new(command).arg(version_flag).output() {
         Ok(output) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,9 +37,7 @@ use models::{
     MessageLog, Mode, RepoSelectPhase, Screen, SessionStates, StateFilter, TextInput,
     REFRESH_INTERVAL, SOCKET_PATH,
 };
-use session::{
-    attach_tmux_session, create_worktree_and_session, expand_editor_command, fetch_sessions,
-};
+use session::{create_worktree_and_session, expand_editor_command, fetch_sessions, Multiplexer};
 use ui::{ui, ui_configuration, ui_dependencies, ui_repo_select};
 
 fn main() -> Result<()> {
@@ -55,7 +53,9 @@ fn main() -> Result<()> {
 
     let mut terminal =
         ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(io::stdout()))?;
-    let mut app = App::new(session_states, message_log);
+    // Detect available multiplexer (tmux preferred, screen as fallback)
+    let multiplexer = Multiplexer::detect().unwrap_or(Multiplexer::Tmux);
+    let mut app = App::new(session_states, message_log, multiplexer);
 
     // Check external dependencies on startup
     let initial_deps = check_dependencies();
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
                         match worktree_result {
                             Ok(()) => {
                                 app.worktrees = fetch_worktrees();
-                                app.sessions = fetch_sessions(&app.session_states);
+                                app.sessions = fetch_sessions(&app.session_states, app.multiplexer);
                                 app.clamp_selected();
                                 app.set_status(format!(
                                     "Created issue #{} with worktree and session",
@@ -504,11 +504,14 @@ fn main() -> Result<()> {
                                                     app.hook_script_path.as_deref(),
                                                     pr_ready,
                                                     claude_cmd.as_deref(),
+                                                    app.multiplexer,
                                                 ) {
                                                     Ok(()) => {
                                                         app.worktrees = fetch_worktrees();
-                                                        app.sessions =
-                                                            fetch_sessions(&app.session_states);
+                                                        app.sessions = fetch_sessions(
+                                                            &app.session_states,
+                                                            app.multiplexer,
+                                                        );
                                                         app.clamp_selected();
                                                         app.last_refresh =
                                                             std::time::Instant::now();
@@ -557,7 +560,7 @@ fn main() -> Result<()> {
                                             let path = card.description.clone();
                                             app.confirm_modal = Some(ConfirmModal {
                                                 message: format!(
-                                                    "Remove worktree '{}'?\n\nPath: {}\nThis will also delete the branch and kill any tmux session.",
+                                                    "Remove worktree '{}'?\n\nPath: {}\nThis will also delete the branch and kill any active session.",
                                                     branch, path
                                                 ),
                                                 on_confirm: ConfirmAction::RemoveWorktree {
@@ -753,7 +756,8 @@ fn main() -> Result<()> {
                                         let session_name = card.title.clone();
                                         app.confirm_modal = Some(ConfirmModal {
                                             message: format!(
-                                                "Kill tmux session '{}'?",
+                                                "Kill {} session '{}'?",
+                                                app.multiplexer.label(),
                                                 session_name
                                             ),
                                             on_confirm: ConfirmAction::KillSession {
@@ -769,7 +773,7 @@ fn main() -> Result<()> {
                                         // Suspend TUI, attach to tmux, resume on detach
                                         disable_raw_mode()?;
                                         io::stdout().execute(LeaveAlternateScreen)?;
-                                        let _ = attach_tmux_session(&session_name);
+                                        let _ = app.multiplexer.attach(&session_name);
                                         enable_raw_mode()?;
                                         io::stdout().execute(EnterAlternateScreen)?;
                                         terminal.clear()?;
@@ -865,11 +869,13 @@ fn main() -> Result<()> {
                                             }
                                         }
                                         ConfirmAction::RemoveWorktree { path, branch } => {
-                                            match remove_worktree(&path, &branch) {
+                                            match remove_worktree(&path, &branch, app.multiplexer) {
                                                 Ok(()) => {
                                                     app.worktrees = fetch_worktrees();
-                                                    app.sessions =
-                                                        fetch_sessions(&app.session_states);
+                                                    app.sessions = fetch_sessions(
+                                                        &app.session_states,
+                                                        app.multiplexer,
+                                                    );
                                                     app.clamp_selected();
                                                     app.last_refresh = std::time::Instant::now();
                                                     app.set_status(format!(
@@ -883,30 +889,22 @@ fn main() -> Result<()> {
                                             }
                                         }
                                         ConfirmAction::KillSession { name } => {
-                                            let output = Command::new("tmux")
-                                                .args(["kill-session", "-t", &name])
-                                                .output();
-                                            match output {
-                                                Ok(o) if o.status.success() => {
-                                                    app.sessions =
-                                                        fetch_sessions(&app.session_states);
-                                                    app.clamp_selected();
-                                                    app.last_refresh = std::time::Instant::now();
-                                                    app.set_status(format!(
-                                                        "Killed session '{}'",
-                                                        name
-                                                    ));
-                                                }
-                                                Ok(o) => {
-                                                    let stderr = String::from_utf8_lossy(&o.stderr);
-                                                    app.set_status(format!(
-                                                        "Error: {}",
-                                                        stderr.trim()
-                                                    ));
-                                                }
-                                                Err(e) => {
-                                                    app.set_status(format!("Error: {}", e));
-                                                }
+                                            let output = app.multiplexer.kill_session(&name);
+                                            if output.status.success() {
+                                                app.sessions = fetch_sessions(
+                                                    &app.session_states,
+                                                    app.multiplexer,
+                                                );
+                                                app.clamp_selected();
+                                                app.last_refresh = std::time::Instant::now();
+                                                app.set_status(format!(
+                                                    "Killed session '{}'",
+                                                    name
+                                                ));
+                                            } else {
+                                                let stderr =
+                                                    String::from_utf8_lossy(&output.stderr);
+                                                app.set_status(format!("Error: {}", stderr.trim()));
                                             }
                                         }
                                         ConfirmAction::RevertPr { number } => {
@@ -1014,8 +1012,12 @@ fn main() -> Result<()> {
                                                         {
                                                             let wt_path = wt.description.clone();
                                                             let wt_branch = wt.title.clone();
-                                                            if remove_worktree(&wt_path, &wt_branch)
-                                                                .is_ok()
+                                                            if remove_worktree(
+                                                                &wt_path,
+                                                                &wt_branch,
+                                                                app.multiplexer,
+                                                            )
+                                                            .is_ok()
                                                             {
                                                                 app.set_status(format!(
                                                                     "Merged PR #{} ({}) — cleaned up worktree '{}'",
@@ -1032,8 +1034,10 @@ fn main() -> Result<()> {
                                                         app.pr_assignee_filter,
                                                     );
                                                     app.worktrees = fetch_worktrees();
-                                                    app.sessions =
-                                                        fetch_sessions(&app.session_states);
+                                                    app.sessions = fetch_sessions(
+                                                        &app.session_states,
+                                                        app.multiplexer,
+                                                    );
                                                     app.clamp_selected();
                                                     app.last_refresh = std::time::Instant::now();
                                                     // Schedule a delayed refresh so GitHub
@@ -1110,6 +1114,7 @@ fn main() -> Result<()> {
                                             let repo = app.repo.clone();
                                             let hook_script = app.hook_script_path.clone();
                                             let claude_cmd = get_session_command(&repo);
+                                            let mux = app.multiplexer;
                                             let (tx, rx) = mpsc::channel();
                                             app.issue_submit_rx = Some(rx);
                                             std::thread::spawn(move || {
@@ -1125,6 +1130,7 @@ fn main() -> Result<()> {
                                                                 hook_script.as_deref(),
                                                                 pr_ready,
                                                                 claude_cmd.as_deref(),
+                                                                mux,
                                                             );
                                                         let _ =
                                                             tx.send(IssueSubmitResult::Success {


### PR DESCRIPTION
## Summary
- Introduces a `Multiplexer` enum in `session.rs` that abstracts all terminal multiplexer operations (create, attach, kill, list, capture-pane, send-keys) for both **tmux** and **GNU Screen**
- Auto-detects tmux on startup; falls back to GNU Screen when tmux is unavailable
- Updates dependency checking to treat tmux/screen as alternatives (like claude/cursor) — only one is required
- Threads the detected multiplexer through all session operations across `session.rs`, `app.rs`, `git.rs`, and `main.rs`

## Test plan
- [x] All existing tests pass (`cargo test` — 6/6)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Verify tmux sessions still work end-to-end (create, attach, kill, status detection)
- [ ] Verify GNU Screen sessions work on a machine without tmux
- [ ] Verify dependency screen shows "tmux/screen" and passes when either is available

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)