### PR TITLE
Make terminal multiplexer optional on dep screen

### DIFF
--- a/src/deps.rs
+++ b/src/deps.rs
@@ -14,26 +14,19 @@ pub fn check_dependencies() -> Vec<Dependency> {
         check_dep("git", "git", "Version control with worktree support", true),
     ];
 
-    // Require at least one terminal multiplexer (tmux or screen)
-    let tmux = check_dep("tmux", "tmux", "Terminal multiplexer for sessions", false);
-    let screen = check_dep(
-        "screen",
-        "screen",
-        "Terminal multiplexer for sessions",
+    // Terminal multiplexers are optional; tmux is preferred
+    deps.push(check_dep(
+        "tmux",
+        "tmux",
+        "Preferred terminal multiplexer for sessions",
         false,
-    );
-    let mux_available = tmux.available || screen.available;
-    deps.push(Dependency {
-        name: "tmux/screen",
-        description: "Terminal multiplexer for sessions (tmux or GNU Screen)",
-        required: true,
-        available: mux_available,
-        version: if tmux.available {
-            tmux.version
-        } else {
-            screen.version
-        },
-    });
+    ));
+    deps.push(check_dep(
+        "screen",
+        "screen",
+        "Alternative terminal multiplexer (GNU Screen)",
+        false,
+    ));
 
     // Require at least one AI coding assistant (claude or cursor)
     let claude = check_dep(


### PR DESCRIPTION
## Summary
- Show tmux and screen as separate optional dependencies on the dependency screen instead of requiring at least one
- tmux is labeled as "Preferred terminal multiplexer for sessions"
- screen is labeled as "Alternative terminal multiplexer (GNU Screen)"

Closes #113

## Test plan
- [ ] Launch the app without tmux or screen installed — verify the dependency screen shows both as yellow MISSING (not red) and allows continuing
- [ ] Launch with tmux installed — verify tmux shows as green OK with "Preferred" in description
- [ ] Launch with both installed — verify both show as green OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)