### PR TITLE
Handle 100s of issues and PRs

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -50,7 +50,7 @@ pub fn fetch_issues(repo: &str, state: StateFilter, assignee: AssigneeFilter) ->
         "--json".to_string(),
         "number,title,body,labels,state".to_string(),
         "--limit".to_string(),
-        "30".to_string(),
+        "500".to_string(),
     ];
     if assignee == AssigneeFilter::Mine {
         args.push("--assignee".to_string());
@@ -139,7 +139,7 @@ pub fn fetch_prs(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Ve
         "--json".to_string(),
         "number,title,body,isDraft,url,headRefName,state,mergedAt".to_string(),
         "--limit".to_string(),
-        "30".to_string(),
+        "500".to_string(),
     ];
     if assignee == AssigneeFilter::Mine {
         args.push("--assignee".to_string());
@@ -299,7 +299,7 @@ pub fn fetch_merged_pr_branches(repo: &str) -> Vec<String> {
             "--json",
             "headRefName",
             "--limit",
-            "30",
+            "500",
         ])
         .output();
 


### PR DESCRIPTION
## Summary
- Increase `gh` fetch limits from 30 to 500 for issues, PRs, and merged PR branches so repos with 100+ items show all results
- Show item counts in all column titles (e.g. `Issues (142) [open|all]`, `Worktrees (5)`, `Sessions (3)`)
- Show filtered/total count in the `/` filter input (e.g. `/ query_ 12/142`) so users know how many results match
- Fix two clippy warnings (`too_many_arguments`, `redundant_pattern_matching`)

Closes #119

## Test plan
- [ ] Run `cargo check` and `cargo clippy -- -W clippy::all` — no errors or warnings
- [ ] Launch against a repo with many issues and confirm all load
- [ ] Use `/` filter and verify the filtered/total count updates as you type
- [ ] Confirm all four column titles show counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)