### PR TITLE
Open current git repo automatically on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,10 +68,11 @@ fn main() -> Result<()> {
         app.screen = Screen::Dependencies;
     } else {
         app.dependencies = initial_deps;
-        // Load saved config, falling back to detecting the current git repo
+        // Detect the current git repo first, falling back to saved config
+        let detected_repo = detect_current_repo();
         let configured_repo = load_config().map(|c| c.repo).filter(|r| !r.is_empty());
 
-        let repo = configured_repo.or_else(detect_current_repo);
+        let repo = detected_repo.or(configured_repo);
 
         if let Some(repo) = repo {
             app.repo = repo.clone();


### PR DESCRIPTION
## Summary
- Prioritize detecting the current git repository over the saved config when the app starts
- If the app is invoked in a directory that is a git repository, it now automatically opens that repository
- The saved config is still used as a fallback when no git repo is detected in the current directory

Closes #120

## Test plan
- [ ] Run octopai from within a git repo directory — it should open that repo
- [ ] Run octopai from a non-git directory with a saved config — it should open the saved repo
- [ ] Run octopai from a non-git directory with no saved config — it should show the repo select screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)