### PR TITLE
Add loading spinner for worktree and session creation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use crate::github::{fetch_issues, fetch_prs};
 use crate::hooks::ensure_hook_script;
 use crate::models::{
     AssigneeFilter, Card, ConfigEditState, ConfirmModal, IssueModal, IssueSubmitResult, MessageLog,
-    Mode, RepoSelectState, Screen, SessionStates, StateFilter, MAX_MESSAGES,
+    Mode, RepoSelectState, Screen, SessionStates, StateFilter, WorktreeCreateResult, MAX_MESSAGES,
 };
 use crate::session::{fetch_sessions, Multiplexer};
 
@@ -33,6 +33,8 @@ pub struct App {
     pub pr_state_filter: StateFilter,
     pub pr_assignee_filter: AssigneeFilter,
     pub issue_submit_rx: Option<mpsc::Receiver<IssueSubmitResult>>,
+    pub worktree_create_rx: Option<mpsc::Receiver<WorktreeCreateResult>>,
+    pub loading_message: Option<String>,
     pub spinner_tick: usize,
     pub dependencies: Vec<Dependency>,
     pub config_edit: Option<ConfigEditState>,
@@ -74,6 +76,8 @@ impl App {
             pr_state_filter: StateFilter::Open,
             pr_assignee_filter: AssigneeFilter::All,
             issue_submit_rx: None,
+            worktree_create_rx: None,
+            loading_message: None,
             spinner_tick: 0,
             dependencies: Vec::new(),
             config_edit: None,

--- a/src/models.rs
+++ b/src/models.rs
@@ -239,6 +239,17 @@ pub enum IssueSubmitResult {
     Error(String),
 }
 
+pub enum WorktreeCreateResult {
+    WorktreeAndSession {
+        number: u64,
+        result: std::result::Result<(), String>,
+    },
+    SessionOnly {
+        branch: String,
+        result: std::result::Result<(), String>,
+    },
+}
+
 pub fn fuzzy_match(query: &str, target: &str) -> bool {
     let target_lower = target.to_lowercase();
     let mut target_chars = target_lower.chars();


### PR DESCRIPTION
## Summary
- Moves worktree/session creation (`w` key on Issues and Worktrees columns) to background threads so the UI stays responsive
- Displays an animated spinner overlay while the operation runs, using the same braille spinner pattern already used for issue creation
- Guards the `w` key handler to prevent duplicate creation while an operation is in progress

Closes #125

## Test plan
- [ ] Press `w` on an issue — verify spinner appears and UI remains responsive
- [ ] Verify worktree and session are created successfully after spinner completes
- [ ] Press `w` on a worktree without a session — verify spinner appears for session creation
- [ ] Press `w` multiple times quickly — verify no duplicate operations are started
- [ ] Verify error messages still display correctly on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)