### PR TITLE
Add option to create issue without worktree and session

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -214,9 +214,10 @@ impl RepoSelectState {
 pub struct IssueModal {
     pub title: TextInput,
     pub body: TextInput,
-    pub active_field: usize, // 0 = title, 1 = body
+    pub active_field: usize, // 0 = title, 1 = body, 2 = create_worktree toggle
     pub error: Option<String>,
     pub submitting: bool,
+    pub create_worktree: bool,
 }
 
 impl IssueModal {
@@ -227,6 +228,7 @@ impl IssueModal {
             active_field: 0,
             error: None,
             submitting: false,
+            create_worktree: true,
         }
     }
 }
@@ -234,7 +236,7 @@ impl IssueModal {
 pub enum IssueSubmitResult {
     Success {
         number: u64,
-        worktree_result: std::result::Result<(), String>,
+        worktree_result: Option<std::result::Result<(), String>>,
     },
     Error(String),
 }


### PR DESCRIPTION
## Summary
- Adds a "Create worktree and session" checkbox toggle to the new issue modal
- When unchecked, creating an issue only opens it on GitHub without spawning a local worktree or multiplexer session
- Defaults to checked, preserving existing behavior
- Toggle with Space or Enter when focused; navigate to it via Tab

Closes #131

## Test plan
- [ ] Create a new issue with the checkbox checked — verify worktree and session are created (existing behavior)
- [ ] Create a new issue with the checkbox unchecked — verify only the GitHub issue is created, no worktree or session
- [ ] Verify Tab cycles through title, body, and checkbox fields
- [ ] Verify Space and Enter toggle the checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)