### PR TITLE
Auto-nudge idle sessions and increase default max turns

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -288,7 +288,7 @@ pub fn fetch_sessions(socket_states: &SessionStates, mux: Multiplexer) -> Vec<Ca
 
 /// Default command template for Claude Code sessions.
 pub const DEFAULT_CLAUDE_COMMAND: &str =
-    "claude \"$(cat '{prompt_file}')\" --allowedTools Read,Edit,Bash";
+    "claude \"$(cat '{prompt_file}')\" --allowedTools Read,Edit,Bash --max-turns 50";
 
 /// Default command template for Cursor sessions.
 pub const DEFAULT_CURSOR_COMMAND: &str = "cursor-agent \"$(cat '{prompt_file}')\"";


### PR DESCRIPTION
## Summary
- Sessions that go idle without creating a PR are automatically nudged with `continue` on the next refresh cycle, reducing stalls caused by Claude hitting its turn limit
- Each session is only nudged once to avoid spamming
- Default `--max-turns` increased to 50, giving Claude more runway to complete the full investigate → implement → commit → PR lifecycle

## Test plan
- [ ] Launch a session and verify it uses `--max-turns 50` in the command
- [ ] Let a session go idle without a PR and confirm the `[monitor] Nudged ...` message appears in the log
- [ ] Confirm the session is only nudged once (not every 30s refresh)
- [ ] Confirm nudge tracking is cleared when a PR appears or the session is killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)