### PR TITLE
Make auto-opening PRs optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::session::Multiplexer;
 
+fn default_auto_open_pr() -> HashMap<String, bool> {
+    HashMap::new()
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct Config {
     pub repo: String,
@@ -16,6 +20,8 @@ pub struct Config {
     pub editor_commands: HashMap<String, String>,
     #[serde(default)]
     pub pr_ready: HashMap<String, bool>,
+    #[serde(default = "default_auto_open_pr")]
+    pub auto_open_pr: HashMap<String, bool>,
     #[serde(default, alias = "claude_commands")]
     pub session_commands: HashMap<String, String>,
     #[serde(default)]
@@ -50,6 +56,10 @@ pub fn save_config(repo: &str) -> Result<()> {
         .as_ref()
         .map(|c| c.pr_ready.clone())
         .unwrap_or_default();
+    let auto_open_pr = existing
+        .as_ref()
+        .map(|c| c.auto_open_pr.clone())
+        .unwrap_or_default();
     let path = config_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -64,6 +74,7 @@ pub fn save_config(repo: &str) -> Result<()> {
         verify_commands,
         editor_commands,
         pr_ready,
+        auto_open_pr,
         session_commands,
         multiplexer,
     };
@@ -101,6 +112,7 @@ pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {
         verify_commands: HashMap::new(),
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
+        auto_open_pr: HashMap::new(),
         session_commands: HashMap::new(),
         multiplexer: None,
     });
@@ -116,6 +128,7 @@ pub fn set_verify_command(repo: &str, command: &str) -> Result<()> {
         verify_commands: HashMap::new(),
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
+        auto_open_pr: HashMap::new(),
         session_commands: HashMap::new(),
         multiplexer: None,
     });
@@ -129,6 +142,12 @@ pub fn get_pr_ready(repo: &str) -> bool {
     load_config()
         .and_then(|c| c.pr_ready.get(repo).copied())
         .unwrap_or(false)
+}
+
+pub fn get_auto_open_pr(repo: &str) -> bool {
+    load_config()
+        .and_then(|c| c.auto_open_pr.get(repo).copied())
+        .unwrap_or(true)
 }
 
 pub fn get_session_command(repo: &str) -> Option<String> {

--- a/src/models.rs
+++ b/src/models.rs
@@ -136,9 +136,10 @@ pub struct ConfigEditState {
     pub verify_command: TextInput,
     pub editor_command: TextInput,
     pub pr_ready: bool,
+    pub auto_open_pr: bool,
     pub session_command: TextInput,
     pub multiplexer: crate::session::Multiplexer,
-    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = session_command, 4 = multiplexer
+    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = auto_open_pr, 4 = session_command, 5 = multiplexer
 }
 
 impl ConfigEditState {
@@ -146,6 +147,7 @@ impl ConfigEditState {
         verify_command: String,
         editor_command: String,
         pr_ready: bool,
+        auto_open_pr: bool,
         session_command: String,
         multiplexer: crate::session::Multiplexer,
     ) -> Self {
@@ -153,6 +155,7 @@ impl ConfigEditState {
             verify_command: TextInput::from(verify_command),
             editor_command: TextInput::from(editor_command),
             pr_ready,
+            auto_open_pr,
             session_command: TextInput::from(session_command),
             multiplexer,
             active_field: 0,

--- a/src/session.rs
+++ b/src/session.rs
@@ -464,6 +464,7 @@ pub fn create_session_for_worktree(
     worktree_path: &str,
     hook_script: Option<&str>,
     pr_ready: bool,
+    auto_open_pr: bool,
     session_command: Option<&str>,
     mux: Multiplexer,
 ) -> std::result::Result<(), String> {
@@ -502,16 +503,22 @@ pub fn create_session_for_worktree(
             .join(" ")
     };
 
-    let pr_instruction = if pr_ready {
-        "open a pull request"
+    let prompt = if auto_open_pr {
+        let pr_instruction = if pr_ready {
+            "open a pull request"
+        } else {
+            "open a draft pull request"
+        };
+        format!(
+            "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and {} with a clear title and description that explains what was changed and why. Reference the issue with 'Closes #{}' in the PR body. Use '--assignee @me' when creating the pull request to auto-assign it.",
+            number, repo, title, body_clean, pr_instruction, number
+        )
     } else {
-        "open a draft pull request"
+        format!(
+            "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and push the branch.",
+            number, repo, title, body_clean
+        )
     };
-
-    let prompt = format!(
-        "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and {} with a clear title and description that explains what was changed and why. Reference the issue with 'Closes #{}' in the PR body. Use '--assignee @me' when creating the pull request to auto-assign it.",
-        number, repo, title, body_clean, pr_instruction, number
-    );
 
     // Write prompt to a temp file for safe shell expansion
     let prompt_file = format!("/tmp/octopai-prompt-{}.txt", number);
@@ -546,6 +553,7 @@ pub fn create_worktree_and_session(
     body: &str,
     hook_script: Option<&str>,
     pr_ready: bool,
+    auto_open_pr: bool,
     session_command: Option<&str>,
     mux: Multiplexer,
 ) -> std::result::Result<(), String> {
@@ -599,16 +607,22 @@ pub fn create_worktree_and_session(
             .join(" ")
     };
 
-    let pr_instruction = if pr_ready {
-        "open a pull request"
+    let prompt = if auto_open_pr {
+        let pr_instruction = if pr_ready {
+            "open a pull request"
+        } else {
+            "open a draft pull request"
+        };
+        format!(
+            "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and {} with a clear title and description that explains what was changed and why. Reference the issue with 'Closes #{}' in the PR body. Use '--assignee @me' when creating the pull request to auto-assign it.",
+            number, repo, title, body_clean, pr_instruction, number
+        )
     } else {
-        "open a draft pull request"
+        format!(
+            "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and push the branch.",
+            number, repo, title, body_clean
+        )
     };
-
-    let prompt = format!(
-        "You are working on GitHub issue #{} for the repo {}. Title: {}. {} Please investigate the codebase and implement a solution for this issue. When you are confident the problem is solved, commit your changes and {} with a clear title and description that explains what was changed and why. Reference the issue with 'Closes #{}' in the PR body. Use '--assignee @me' when creating the pull request to auto-assign it.",
-        number, repo, title, body_clean, pr_instruction, number
-    );
 
     // Write prompt to a temp file for safe shell expansion
     let prompt_file = format!("/tmp/octopai-prompt-{}.txt", number);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1350,31 +1350,35 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(1), // verify label
-                Constraint::Length(3), // verify input
-                Constraint::Length(1), // spacing
-                Constraint::Length(1), // editor label
-                Constraint::Length(3), // editor input
-                Constraint::Length(1), // spacing
-                Constraint::Length(1), // pr ready label
-                Constraint::Length(1), // pr ready toggle
-                Constraint::Length(1), // spacing
-                Constraint::Length(1), // session command label
-                Constraint::Length(3), // session command input
-                Constraint::Length(1), // spacing
-                Constraint::Length(1), // multiplexer label
-                Constraint::Length(1), // multiplexer toggle
-                Constraint::Length(1), // spacing
-                Constraint::Length(1), // template fields header
-                Constraint::Min(0),    // template fields list + config path
+                Constraint::Length(1), // 0: verify label
+                Constraint::Length(3), // 1: verify input
+                Constraint::Length(1), // 2: spacing
+                Constraint::Length(1), // 3: editor label
+                Constraint::Length(3), // 4: editor input
+                Constraint::Length(1), // 5: spacing
+                Constraint::Length(1), // 6: pr ready label
+                Constraint::Length(1), // 7: pr ready toggle
+                Constraint::Length(1), // 8: spacing
+                Constraint::Length(1), // 9: auto open pr label
+                Constraint::Length(1), // 10: auto open pr toggle
+                Constraint::Length(1), // 11: spacing
+                Constraint::Length(1), // 12: session command label
+                Constraint::Length(3), // 13: session command input
+                Constraint::Length(1), // 14: spacing
+                Constraint::Length(1), // 15: multiplexer label
+                Constraint::Length(1), // 16: multiplexer toggle
+                Constraint::Length(1), // 17: spacing
+                Constraint::Length(1), // 18: template fields header
+                Constraint::Min(0),    // 19: template fields list + config path
             ])
             .split(inner);
 
         let verify_active = config_edit.active_field == 0;
         let editor_active = config_edit.active_field == 1;
         let pr_ready_active = config_edit.active_field == 2;
-        let session_active = config_edit.active_field == 3;
-        let mux_active = config_edit.active_field == 4;
+        let auto_open_pr_active = config_edit.active_field == 3;
+        let session_active = config_edit.active_field == 4;
+        let mux_active = config_edit.active_field == 5;
 
         // Verify command field
         let verify_label = Paragraph::new(Line::from(vec![Span::styled(
@@ -1494,6 +1498,47 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
         ]));
         frame.render_widget(pr_ready_text, chunks[7]);
 
+        // Auto Open PR toggle field
+        let auto_open_pr_label = Paragraph::new(Line::from(vec![Span::styled(
+            "Auto Open PRs",
+            Style::default()
+                .fg(if auto_open_pr_active {
+                    Color::Cyan
+                } else {
+                    Color::Gray
+                })
+                .add_modifier(Modifier::BOLD),
+        )]));
+        frame.render_widget(auto_open_pr_label, chunks[9]);
+
+        let auto_open_checkbox = if config_edit.auto_open_pr {
+            "[x]"
+        } else {
+            "[ ]"
+        };
+        let auto_open_toggle_color = if auto_open_pr_active {
+            Color::White
+        } else {
+            Color::DarkGray
+        };
+        let auto_open_pr_text = Paragraph::new(Line::from(vec![
+            Span::styled(
+                auto_open_checkbox,
+                Style::default()
+                    .fg(auto_open_toggle_color)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                if config_edit.auto_open_pr {
+                    "  Enabled — sessions will auto-open PRs"
+                } else {
+                    "  Disabled — sessions will only commit and push"
+                },
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]));
+        frame.render_widget(auto_open_pr_text, chunks[10]);
+
         // Session command field
         let session_label = Paragraph::new(Line::from(vec![Span::styled(
             "Session Command",
@@ -1505,7 +1550,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 })
                 .add_modifier(Modifier::BOLD),
         )]));
-        frame.render_widget(session_label, chunks[9]);
+        frame.render_widget(session_label, chunks[12]);
 
         let session_border = if session_active {
             Style::default()
@@ -1534,7 +1579,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
             )
         };
         let session_text = Paragraph::new(Line::from(session_spans)).block(session_block);
-        frame.render_widget(session_text, chunks[10]);
+        frame.render_widget(session_text, chunks[13]);
 
         // Multiplexer toggle field
         let mux_label = Paragraph::new(Line::from(vec![Span::styled(
@@ -1543,7 +1588,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 .fg(if mux_active { Color::Cyan } else { Color::Gray })
                 .add_modifier(Modifier::BOLD),
         )]));
-        frame.render_widget(mux_label, chunks[12]);
+        frame.render_widget(mux_label, chunks[15]);
 
         let mux_toggle_color = if mux_active {
             Color::White
@@ -1568,7 +1613,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 Style::default().fg(Color::DarkGray),
             ),
         ]));
-        frame.render_widget(mux_text, chunks[13]);
+        frame.render_widget(mux_text, chunks[16]);
 
         // Template fields header
         let fields_header = Paragraph::new(Line::from(vec![Span::styled(
@@ -1577,7 +1622,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
                 .fg(Color::Gray)
                 .add_modifier(Modifier::BOLD),
         )]));
-        frame.render_widget(fields_header, chunks[15]);
+        frame.render_widget(fields_header, chunks[18]);
 
         // Template fields list + config path in the remaining space
         let mut lines: Vec<Line> = Vec::new();
@@ -1648,7 +1693,7 @@ pub fn ui_configuration(frame: &mut Frame, app: &App) {
             ),
         ]));
         let fields_list = Paragraph::new(lines);
-        frame.render_widget(fields_list, chunks[16]);
+        frame.render_widget(fields_list, chunks[19]);
     }
 
     // Bottom hint bar


### PR DESCRIPTION
## Summary
- Adds a new per-repo `auto_open_pr` configuration option (defaults to enabled)
- When disabled, AI sessions will only commit and push the branch instead of automatically opening a pull request
- New toggle is accessible in the Configuration screen (`C` key), between the existing "PR Ready" and "Session Command" fields

## Test plan
- [ ] Open config screen (`C`), verify new "Auto Open PRs" toggle appears
- [ ] Toggle it off, save, create a worktree session — verify the prompt instructs to "commit and push" without PR instructions
- [ ] Toggle it on, save, create a worktree session — verify the prompt includes PR creation instructions as before
- [ ] Verify existing configs without `auto_open_pr` field load correctly (defaults to true)

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)