### PR TITLE
Setup initial config for AI coding assistant

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,9 @@ use crate::git::{cleanup_merged_worktrees, fetch_main_behind_count, fetch_worktr
 use crate::github::{fetch_issues, fetch_prs};
 use crate::hooks::ensure_hook_script;
 use crate::models::{
-    AssigneeFilter, Card, ConfigEditState, ConfirmModal, IssueModal, IssueSubmitResult, MessageLog,
-    Mode, RepoSelectState, Screen, SessionStates, StateFilter, WorktreeCreateResult, MAX_MESSAGES,
+    AiSetupState, AssigneeFilter, Card, ConfigEditState, ConfirmModal, IssueModal,
+    IssueSubmitResult, MessageLog, Mode, RepoSelectState, Screen, SessionStates, StateFilter,
+    WorktreeCreateResult, MAX_MESSAGES,
 };
 use crate::session::{fetch_sessions, Multiplexer};
 
@@ -47,6 +48,7 @@ pub struct App {
     /// Tracks sessions that have been nudged to continue (to avoid repeated nudges).
     /// Maps branch name to the number of nudges sent.
     pub nudged_sessions: HashMap<String, usize>,
+    pub ai_setup: Option<AiSetupState>,
 }
 
 impl App {
@@ -91,6 +93,7 @@ impl App {
             main_behind_count: 0,
             multiplexer,
             nudged_sessions: HashMap::new(),
+            ai_setup: None,
         }
     }
 

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -105,3 +105,19 @@ fn check_dep(
 pub fn has_missing_required(deps: &[Dependency]) -> bool {
     deps.iter().any(|d| d.required && !d.available)
 }
+
+/// Detect which AI coding assistants are available on the system.
+/// Returns `(claude_available, cursor_available)`.
+pub fn detect_ai_tools() -> (bool, bool) {
+    let claude = Command::new("which")
+        .arg("claude")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let cursor = Command::new("which")
+        .arg("cursor-agent")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    (claude, cursor)
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -130,6 +130,17 @@ pub enum Screen {
     Board,
     Dependencies,
     Configuration,
+    AiSetup,
+}
+
+pub struct AiSetupState {
+    pub selected: usize, // 0 = Claude, 1 = Cursor
+}
+
+impl AiSetupState {
+    pub fn new() -> Self {
+        Self { selected: 0 }
+    }
 }
 
 pub struct ConfigEditState {

--- a/src/session.rs
+++ b/src/session.rs
@@ -525,7 +525,10 @@ pub fn create_session_for_worktree(
     fs::write(&prompt_file, &prompt).map_err(|e| format!("Failed to write prompt file: {}", e))?;
 
     // Send session command to the single pane
-    let template = session_command.unwrap_or(DEFAULT_CLAUDE_COMMAND);
+    let global_default = crate::config::get_default_session_command();
+    let template = session_command
+        .or(global_default.as_deref())
+        .unwrap_or(DEFAULT_CLAUDE_COMMAND);
     let shell_cmd = expand_template(
         template,
         &prompt_file,
@@ -629,7 +632,10 @@ pub fn create_worktree_and_session(
     fs::write(&prompt_file, &prompt).map_err(|e| format!("Failed to write prompt file: {}", e))?;
 
     // Send session command to the single pane
-    let template = session_command.unwrap_or(DEFAULT_CLAUDE_COMMAND);
+    let global_default = crate::config::get_default_session_command();
+    let template = session_command
+        .or(global_default.as_deref())
+        .unwrap_or(DEFAULT_CLAUDE_COMMAND);
     let shell_cmd = expand_template(
         template,
         &prompt_file,


### PR DESCRIPTION
## Summary
- Detects whether Claude Code and/or Cursor CLI are installed at startup
- If only one AI tool is found, automatically configures it as the default session command
- If both are found, displays a selection screen prompting the user to choose their preferred assistant
- Persists the choice as `default_session_command` in `~/.config/octopai/config.json`, used as fallback when no per-repo session command is set

## Changes
- **deps.rs**: Added `detect_ai_tools()` function returning individual claude/cursor availability
- **config.rs**: Added `default_session_command` field to `Config` with getter/setter functions
- **models.rs**: Added `AiSetup` screen variant and `AiSetupState` for the selection UI
- **main.rs**: Added startup logic to auto-configure or prompt for AI tool selection
- **session.rs**: Updated session creation to use global default before hardcoded fallback
- **ui.rs**: Added `ui_ai_setup` rendering function for the selection screen
- **app.rs**: Added `ai_setup` state field to `App`

## Test plan
- [ ] Launch with only `claude` installed — should auto-configure without prompting
- [ ] Launch with only `cursor-agent` installed — should auto-configure without prompting
- [ ] Launch with both installed and no existing config — should show selection screen
- [ ] Launch with existing `default_session_command` in config — should skip setup
- [ ] Verify selection persists across restarts
- [ ] Verify per-repo `session_commands` override still takes priority

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)