### PR TITLE
Add edit GitHub issues feature

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,9 +7,9 @@ use crate::git::{cleanup_merged_worktrees, fetch_main_behind_count, fetch_worktr
 use crate::github::{fetch_issues, fetch_prs};
 use crate::hooks::ensure_hook_script;
 use crate::models::{
-    AiSetupState, AssigneeFilter, Card, ConfigEditState, ConfirmModal, IssueModal,
-    IssueSubmitResult, MessageLog, Mode, RepoSelectState, Screen, SessionStates, StateFilter,
-    WorktreeCreateResult, MAX_MESSAGES,
+    AiSetupState, AssigneeFilter, Card, ConfigEditState, ConfirmModal, EditIssueModal,
+    IssueEditResult, IssueModal, IssueSubmitResult, MessageLog, Mode, RepoSelectState, Screen,
+    SessionStates, StateFilter, WorktreeCreateResult, MAX_MESSAGES,
 };
 use crate::session::{fetch_sessions, Multiplexer};
 
@@ -34,6 +34,8 @@ pub struct App {
     pub pr_state_filter: StateFilter,
     pub pr_assignee_filter: AssigneeFilter,
     pub issue_submit_rx: Option<mpsc::Receiver<IssueSubmitResult>>,
+    pub issue_edit_rx: Option<mpsc::Receiver<IssueEditResult>>,
+    pub edit_issue_modal: Option<EditIssueModal>,
     pub worktree_create_rx: Option<mpsc::Receiver<WorktreeCreateResult>>,
     pub loading_message: Option<String>,
     pub spinner_tick: usize,
@@ -81,6 +83,8 @@ impl App {
             pr_state_filter: StateFilter::Open,
             pr_assignee_filter: AssigneeFilter::All,
             issue_submit_rx: None,
+            issue_edit_rx: None,
+            edit_issue_modal: None,
             worktree_create_rx: None,
             loading_message: None,
             spinner_tick: 0,

--- a/src/github.rs
+++ b/src/github.rs
@@ -273,6 +273,35 @@ pub fn fetch_issue(repo: &str, number: u64) -> std::result::Result<(String, Stri
     Ok((title, body))
 }
 
+pub fn edit_issue(
+    repo: &str,
+    number: u64,
+    title: &str,
+    body: &str,
+) -> std::result::Result<(), String> {
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "edit",
+            &number.to_string(),
+            "--repo",
+            repo,
+            "--title",
+            title,
+            "--body",
+            body,
+        ])
+        .output()
+        .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("gh error: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
 pub fn close_issue(repo: &str, number: u64) -> std::result::Result<(), String> {
     let output = Command::new("gh")
         .args(["issue", "close", "--repo", repo, &number.to_string()])

--- a/src/models.rs
+++ b/src/models.rs
@@ -119,6 +119,7 @@ pub enum Mode {
     Normal,
     Filtering { query: TextInput, focused: bool },
     CreatingIssue,
+    EditingIssue,
     Confirming,
     EditingVerifyCommand { input: TextInput },
     EditingEditorCommand { input: TextInput },
@@ -252,6 +253,33 @@ pub enum IssueSubmitResult {
         number: u64,
         worktree_result: Option<std::result::Result<(), String>>,
     },
+    Error(String),
+}
+
+pub struct EditIssueModal {
+    pub number: u64,
+    pub title: TextInput,
+    pub body: TextInput,
+    pub active_field: usize, // 0 = title, 1 = body
+    pub error: Option<String>,
+    pub submitting: bool,
+}
+
+impl EditIssueModal {
+    pub fn new(number: u64, title: String, body: String) -> Self {
+        Self {
+            number,
+            title: TextInput::from(title),
+            body: TextInput::from(body),
+            active_field: 0,
+            error: None,
+            submitting: false,
+        }
+    }
+}
+
+pub enum IssueEditResult {
+    Success { number: u64 },
     Error(String),
 }
 


### PR DESCRIPTION
## Summary
- Add ability to edit existing GitHub issues directly from the TUI
- Press `e` while focused on the Issues column to open an edit modal pre-populated with the issue's current title and body
- Submits changes via `gh issue edit` in a background thread with spinner feedback
- Refreshes the issue list automatically on success

## Changes
- **github.rs**: Add `edit_issue()` function that calls `gh issue edit`
- **models.rs**: Add `EditIssueModal`, `IssueEditResult`, and `EditingIssue` mode
- **app.rs**: Add `edit_issue_modal` and `issue_edit_rx` state fields
- **main.rs**: Add `e` keybinding, `EditingIssue` mode input handling, and background result processing
- **ui.rs**: Add edit issue modal rendering and `e` key in the Issues legend bar

Closes #145

## Test plan
- [ ] Select an issue and press `e` — modal opens with current title/body
- [ ] Edit the title and body, press `Ctrl+S` — issue updates on GitHub
- [ ] Press `Esc` to cancel without changes
- [ ] Verify spinner shows during submission
- [ ] Verify error displays if submission fails
- [ ] Verify issue list refreshes after successful edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)