### PR TITLE
Add main worktree Claude exploration session

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -630,6 +630,8 @@ pub fn ui(frame: &mut Frame, app: &App) {
                 Span::styled(" Pull ", desc_style),
                 Span::styled(" n ", key_accent),
                 Span::styled(" New issue ", desc_style),
+                Span::styled(" t ", key_accent),
+                Span::styled(" Main Claude ", desc_style),
                 Span::styled(" D ", key_style),
                 Span::styled(" Deps ", desc_style),
                 Span::styled(" C ", key_style),


### PR DESCRIPTION
## Summary
- Adds a `t` keybinding that toggles a Claude session on the main worktree for free-form exploration
- Creates the session if it doesn't exist, then attaches to it (suspending the TUI)
- The session runs `claude` with no prompt — purely for codebase exploration

## Changes
- **`session.rs`**: Added `ensure_main_session()` function that creates a "main-explore" multiplexer session running `claude` with no arguments
- **`main.rs`**: Added `t` keybinding handler that creates-if-needed and attaches to the main exploration session
- **`ui.rs`**: Added `t Main Claude` to the global legend bar

## Test plan
- [ ] Press `t` on the board screen — should create and attach to a Claude session in the main worktree
- [ ] Press `t` again after detaching — should reattach to the existing session (not create a new one)
- [ ] Verify the session appears in `tmux list-sessions` as "main-explore"

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)