### PR TITLE
Add local issues feature

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use crate::deps::Dependency;
 use crate::git::{cleanup_merged_worktrees, fetch_main_behind_count, fetch_worktrees};
 use crate::github::{fetch_issues, fetch_prs};
 use crate::hooks::ensure_hook_script;
+use crate::local_issues::fetch_local_issues;
 use crate::models::{
     AiSetupState, AssigneeFilter, Card, ConfigEditState, ConfirmModal, EditIssueModal,
     IssueEditResult, IssueModal, IssueSubmitResult, MessageLog, Mode, RepoSelectState, Screen,
@@ -194,11 +195,14 @@ impl App {
     }
 
     pub fn refresh_data(&mut self) {
-        self.issues = fetch_issues(
+        let mut issues = fetch_issues(
             &self.repo,
             self.issue_state_filter,
             self.issue_assignee_filter,
         );
+        let local = fetch_local_issues(&self.repo, self.issue_state_filter.label());
+        issues.extend(local);
+        self.issues = issues;
         self.pull_requests = fetch_prs(&self.repo, self.pr_state_filter, self.pr_assignee_filter);
         self.worktrees = fetch_worktrees();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -105,6 +105,7 @@ pub fn fetch_worktrees() -> Vec<Card> {
             is_draft: None,
             is_merged: None,
             head_branch: None,
+            is_local: false,
         });
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -120,6 +120,7 @@ pub fn fetch_issues(repo: &str, state: StateFilter, assignee: AssigneeFilter) ->
                 is_draft: None,
                 is_merged: None,
                 head_branch: None,
+                is_local: false,
             }
         })
         .collect();
@@ -203,6 +204,7 @@ pub fn fetch_prs(repo: &str, state: StateFilter, assignee: AssigneeFilter) -> Ve
                 is_draft: Some(is_draft),
                 is_merged: Some(is_merged),
                 head_branch: Some(branch),
+                is_local: false,
             }
         })
         .collect();

--- a/src/local_issues.rs
+++ b/src/local_issues.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::path::PathBuf;
+
+use ratatui::style::Color;
+use serde::{Deserialize, Serialize};
+
+use crate::models::Card;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LocalIssue {
+    pub id: u64,
+    pub title: String,
+    pub body: String,
+    pub state: String, // "open" or "closed"
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct LocalIssueStore {
+    next_id: u64,
+    issues: Vec<LocalIssue>,
+}
+
+fn store_path(repo: &str) -> PathBuf {
+    let slug = repo.replace('/', "-");
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("octopai")
+        .join("local_issues")
+        .join(format!("{}.json", slug))
+}
+
+fn load_store(repo: &str) -> LocalIssueStore {
+    let path = store_path(repo);
+    let data = match fs::read_to_string(path) {
+        Ok(d) => d,
+        Err(_) => return LocalIssueStore::default(),
+    };
+    serde_json::from_str(&data).unwrap_or_default()
+}
+
+fn save_store(repo: &str, store: &LocalIssueStore) -> Result<(), String> {
+    let path = store_path(repo);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create directory: {}", e))?;
+    }
+    let json =
+        serde_json::to_string_pretty(store).map_err(|e| format!("Failed to serialize: {}", e))?;
+    fs::write(path, json).map_err(|e| format!("Failed to write: {}", e))
+}
+
+pub fn fetch_local_issues(repo: &str, state_filter: &str) -> Vec<Card> {
+    let store = load_store(repo);
+    store
+        .issues
+        .iter()
+        .filter(|issue| issue.state == state_filter)
+        .map(|issue| {
+            let description = if issue.body.len() > 80 {
+                format!("{}...", &issue.body[..77])
+            } else if issue.body.is_empty() {
+                "No description".to_string()
+            } else {
+                issue.body.clone()
+            };
+            let full_description = if issue.body.is_empty() {
+                None
+            } else {
+                Some(issue.body.clone())
+            };
+            Card {
+                id: format!("local-{}", issue.id),
+                title: format!("L-{} {}", issue.id, issue.title),
+                description,
+                full_description,
+                tag: "local".to_string(),
+                tag_color: Color::Cyan,
+                related: Vec::new(),
+                url: None,
+                pr_number: None,
+                is_draft: None,
+                is_merged: None,
+                head_branch: None,
+                is_local: true,
+            }
+        })
+        .collect()
+}
+
+pub fn create_local_issue(repo: &str, title: &str, body: &str) -> Result<u64, String> {
+    let mut store = load_store(repo);
+    store.next_id += 1;
+    let id = store.next_id;
+    store.issues.push(LocalIssue {
+        id,
+        title: title.to_string(),
+        body: body.to_string(),
+        state: "open".to_string(),
+    });
+    save_store(repo, &store)?;
+    Ok(id)
+}
+
+pub fn edit_local_issue(repo: &str, id: u64, title: &str, body: &str) -> Result<(), String> {
+    let mut store = load_store(repo);
+    if let Some(issue) = store.issues.iter_mut().find(|i| i.id == id) {
+        issue.title = title.to_string();
+        issue.body = body.to_string();
+        save_store(repo, &store)
+    } else {
+        Err(format!("Local issue L-{} not found", id))
+    }
+}
+
+pub fn close_local_issue(repo: &str, id: u64) -> Result<(), String> {
+    let mut store = load_store(repo);
+    if let Some(issue) = store.issues.iter_mut().find(|i| i.id == id) {
+        issue.state = "closed".to_string();
+        save_store(repo, &store)
+    } else {
+        Err(format!("Local issue L-{} not found", id))
+    }
+}
+
+#[allow(dead_code)]
+pub fn fetch_local_issue(repo: &str, id: u64) -> Result<(String, String), String> {
+    let store = load_store(repo);
+    if let Some(issue) = store.issues.iter().find(|i| i.id == id) {
+        Ok((issue.title.clone(), issue.body.clone()))
+    } else {
+        Err(format!("Local issue L-{} not found", id))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod deps;
 mod git;
 mod github;
 mod hooks;
+mod local_issues;
 mod models;
 mod session;
 mod ui;
@@ -34,6 +35,7 @@ use github::{
     close_issue, create_issue, edit_issue, fetch_issue, fetch_issues, fetch_prs, fetch_repos,
 };
 use hooks::start_event_socket;
+use local_issues::{close_local_issue, create_local_issue, edit_local_issue};
 use models::{
     AiSetupState, ConfigEditState, ConfirmAction, ConfirmModal, EditIssueModal, IssueEditResult,
     IssueModal, IssueSubmitResult, MergeStrategy, MessageLog, Mode, RepoSelectPhase, Screen,
@@ -154,11 +156,7 @@ fn main() -> Result<()> {
                         worktree_result,
                         ..
                     } => {
-                        app.issues = fetch_issues(
-                            &app.repo,
-                            app.issue_state_filter,
-                            app.issue_assignee_filter,
-                        );
+                        app.refresh_data();
                         app.clamp_selected();
                         app.last_refresh = std::time::Instant::now();
                         app.issue_modal = None;
@@ -200,13 +198,7 @@ fn main() -> Result<()> {
                 app.issue_edit_rx = None;
                 match result {
                     IssueEditResult::Success { number } => {
-                        app.issues = fetch_issues(
-                            &app.repo,
-                            app.issue_state_filter,
-                            app.issue_assignee_filter,
-                        );
-                        app.clamp_selected();
-                        app.last_refresh = std::time::Instant::now();
+                        app.refresh_data();
                         app.edit_issue_modal = None;
                         app.mode = Mode::Normal;
                         app.set_status(format!("Updated issue #{}", number));
@@ -688,47 +680,58 @@ fn main() -> Result<()> {
                                         && app.worktree_create_rx.is_none() =>
                                 {
                                     if let Some(card) = app.issues.get(app.selected_card[0]) {
-                                        // Extract issue number from id "issue-N"
-                                        if let Some(num_str) = card.id.strip_prefix("issue-") {
-                                            if let Ok(number) = num_str.parse::<u64>() {
-                                                let title = card.title.clone();
-                                                let body = card
-                                                    .full_description
-                                                    .clone()
-                                                    .unwrap_or_default();
-                                                let repo = app.repo.clone();
-                                                let pr_ready = get_pr_ready(&repo);
-                                                let auto_open_pr = get_auto_open_pr(&repo);
-                                                let claude_cmd = get_session_command(&repo);
-                                                let hook_script = app.hook_script_path.clone();
-                                                let mux = app.multiplexer;
-                                                let (tx, rx) = mpsc::channel();
-                                                app.worktree_create_rx = Some(rx);
-                                                app.loading_message = Some(format!(
-                                                    "Creating worktree and session for issue #{}...",
-                                                    number
-                                                ));
-                                                std::thread::spawn(move || {
-                                                    let result = create_worktree_and_session(
-                                                        &repo,
+                                        // Extract issue number from id "issue-N" or "local-N"
+                                        let issue_number = if let Some(num_str) =
+                                            card.id.strip_prefix("issue-")
+                                        {
+                                            num_str.parse::<u64>().ok()
+                                        } else if let Some(id_str) = card.id.strip_prefix("local-")
+                                        {
+                                            id_str.parse::<u64>().ok()
+                                        } else {
+                                            None
+                                        };
+                                        if let Some(number) = issue_number {
+                                            let title = card.title.clone();
+                                            let body =
+                                                card.full_description.clone().unwrap_or_default();
+                                            let repo = app.repo.clone();
+                                            let pr_ready = get_pr_ready(&repo);
+                                            let auto_open_pr = get_auto_open_pr(&repo);
+                                            let claude_cmd = get_session_command(&repo);
+                                            let hook_script = app.hook_script_path.clone();
+                                            let mux = app.multiplexer;
+                                            let (tx, rx) = mpsc::channel();
+                                            app.worktree_create_rx = Some(rx);
+                                            let label = if card.is_local {
+                                                format!("L-{}", number)
+                                            } else {
+                                                format!("#{}", number)
+                                            };
+                                            app.loading_message = Some(format!(
+                                                "Creating worktree and session for issue {}...",
+                                                label
+                                            ));
+                                            std::thread::spawn(move || {
+                                                let result = create_worktree_and_session(
+                                                    &repo,
+                                                    number,
+                                                    &title,
+                                                    &body,
+                                                    hook_script.as_deref(),
+                                                    pr_ready,
+                                                    auto_open_pr,
+                                                    claude_cmd.as_deref(),
+                                                    mux,
+                                                )
+                                                .map_err(|e| e.to_string());
+                                                let _ = tx.send(
+                                                    WorktreeCreateResult::WorktreeAndSession {
                                                         number,
-                                                        &title,
-                                                        &body,
-                                                        hook_script.as_deref(),
-                                                        pr_ready,
-                                                        auto_open_pr,
-                                                        claude_cmd.as_deref(),
-                                                        mux,
-                                                    )
-                                                    .map_err(|e| e.to_string());
-                                                    let _ = tx.send(
-                                                        WorktreeCreateResult::WorktreeAndSession {
-                                                            number,
-                                                            result,
-                                                        },
-                                                    );
-                                                });
-                                            }
+                                                        result,
+                                                    },
+                                                );
+                                            });
                                         }
                                     }
                                 }
@@ -737,7 +740,22 @@ fn main() -> Result<()> {
                                         && app.issue_state_filter == StateFilter::Open =>
                                 {
                                     if let Some(card) = app.issues.get(app.selected_card[0]) {
-                                        if let Some(num_str) = card.id.strip_prefix("issue-") {
+                                        if card.is_local {
+                                            if let Some(id_str) = card.id.strip_prefix("local-") {
+                                                if let Ok(id) = id_str.parse::<u64>() {
+                                                    app.confirm_modal = Some(ConfirmModal {
+                                                        message: format!(
+                                                            "Close local issue L-{}?\n\n{}",
+                                                            id, card.title
+                                                        ),
+                                                        on_confirm:
+                                                            ConfirmAction::CloseLocalIssue { id },
+                                                    });
+                                                    app.mode = Mode::Confirming;
+                                                }
+                                            }
+                                        } else if let Some(num_str) = card.id.strip_prefix("issue-")
+                                        {
                                             if let Ok(number) = num_str.parse::<u64>() {
                                                 app.confirm_modal = Some(ConfirmModal {
                                                     message: format!(
@@ -755,7 +773,26 @@ fn main() -> Result<()> {
                                 }
                                 KeyCode::Char('e') if app.active_section == 0 => {
                                     if let Some(card) = app.issues.get(app.selected_card[0]) {
-                                        if let Some(num_str) = card.id.strip_prefix("issue-") {
+                                        if card.is_local {
+                                            if let Some(id_str) = card.id.strip_prefix("local-") {
+                                                if let Ok(id) = id_str.parse::<u64>() {
+                                                    let title = card
+                                                        .title
+                                                        .strip_prefix(&format!("L-{} ", id))
+                                                        .unwrap_or(&card.title)
+                                                        .to_string();
+                                                    let body = card
+                                                        .full_description
+                                                        .clone()
+                                                        .unwrap_or_default();
+                                                    app.edit_issue_modal = Some(
+                                                        EditIssueModal::new_local(id, title, body),
+                                                    );
+                                                    app.mode = Mode::EditingIssue;
+                                                }
+                                            }
+                                        } else if let Some(num_str) = card.id.strip_prefix("issue-")
+                                        {
                                             if let Ok(number) = num_str.parse::<u64>() {
                                                 // Extract title without the "#N " prefix
                                                 let title = card
@@ -1186,6 +1223,21 @@ fn main() -> Result<()> {
                                                 }
                                             }
                                         }
+                                        ConfirmAction::CloseLocalIssue { id } => {
+                                            let repo = app.repo.clone();
+                                            match close_local_issue(&repo, id) {
+                                                Ok(()) => {
+                                                    app.refresh_data();
+                                                    app.set_status(format!(
+                                                        "Closed local issue L-{}",
+                                                        id
+                                                    ));
+                                                }
+                                                Err(e) => {
+                                                    app.set_status(format!("Error: {}", e));
+                                                }
+                                            }
+                                        }
                                         ConfirmAction::RemoveWorktree { path, branch } => {
                                             match remove_worktree(&path, &branch, app.multiplexer) {
                                                 Ok(()) => {
@@ -1406,6 +1458,7 @@ fn main() -> Result<()> {
                                         modal.active_field = match modal.active_field {
                                             0 => 1,
                                             1 => 2,
+                                            2 => 3,
                                             _ => 0,
                                         };
                                     }
@@ -1418,6 +1471,12 @@ fn main() -> Result<()> {
                                     KeyCode::Enter if modal.active_field == 2 => {
                                         modal.create_worktree = !modal.create_worktree;
                                     }
+                                    KeyCode::Char(' ') if modal.active_field == 3 => {
+                                        modal.local_only = !modal.local_only;
+                                    }
+                                    KeyCode::Enter if modal.active_field == 3 => {
+                                        modal.local_only = !modal.local_only;
+                                    }
                                     KeyCode::Char('s')
                                         if key.modifiers.contains(KeyModifiers::CONTROL)
                                             && !modal.submitting =>
@@ -1425,6 +1484,24 @@ fn main() -> Result<()> {
                                         let title = modal.title.value().trim().to_string();
                                         if title.is_empty() {
                                             modal.error = Some("Title cannot be empty".to_string());
+                                        } else if modal.local_only {
+                                            // Create local issue synchronously
+                                            let body = modal.body.value().to_string();
+                                            let repo = app.repo.clone();
+                                            match create_local_issue(&repo, &title, &body) {
+                                                Ok(id) => {
+                                                    app.issue_modal = None;
+                                                    app.mode = Mode::Normal;
+                                                    app.refresh_data();
+                                                    app.set_status(format!(
+                                                        "Created local issue L-{}",
+                                                        id
+                                                    ));
+                                                }
+                                                Err(e) => {
+                                                    modal.error = Some(e);
+                                                }
+                                            }
                                         } else {
                                             modal.submitting = true;
                                             modal.error = None;
@@ -1585,6 +1662,24 @@ fn main() -> Result<()> {
                                         let title = modal.title.value().trim().to_string();
                                         if title.is_empty() {
                                             modal.error = Some("Title cannot be empty".to_string());
+                                        } else if modal.is_local {
+                                            let body = modal.body.value().to_string();
+                                            let repo = app.repo.clone();
+                                            let id = modal.number;
+                                            match edit_local_issue(&repo, id, &title, &body) {
+                                                Ok(()) => {
+                                                    app.edit_issue_modal = None;
+                                                    app.mode = Mode::Normal;
+                                                    app.refresh_data();
+                                                    app.set_status(format!(
+                                                        "Updated local issue L-{}",
+                                                        id
+                                                    ));
+                                                }
+                                                Err(e) => {
+                                                    modal.error = Some(e);
+                                                }
+                                            }
                                         } else {
                                             modal.submitting = true;
                                             modal.error = None;

--- a/src/models.rs
+++ b/src/models.rs
@@ -24,6 +24,7 @@ pub struct Card {
     pub is_draft: Option<bool>,
     pub is_merged: Option<bool>,
     pub head_branch: Option<String>,
+    pub is_local: bool,
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -91,6 +92,9 @@ impl MergeStrategy {
 pub enum ConfirmAction {
     CloseIssue {
         number: u64,
+    },
+    CloseLocalIssue {
+        id: u64,
     },
     RemoveWorktree {
         path: String,
@@ -229,10 +233,11 @@ impl RepoSelectState {
 pub struct IssueModal {
     pub title: TextInput,
     pub body: TextInput,
-    pub active_field: usize, // 0 = title, 1 = body, 2 = create_worktree toggle
+    pub active_field: usize, // 0 = title, 1 = body, 2 = create_worktree toggle, 3 = local_only toggle
     pub error: Option<String>,
     pub submitting: bool,
     pub create_worktree: bool,
+    pub local_only: bool,
 }
 
 impl IssueModal {
@@ -244,6 +249,7 @@ impl IssueModal {
             error: None,
             submitting: false,
             create_worktree: true,
+            local_only: false,
         }
     }
 }
@@ -263,6 +269,7 @@ pub struct EditIssueModal {
     pub active_field: usize, // 0 = title, 1 = body
     pub error: Option<String>,
     pub submitting: bool,
+    pub is_local: bool,
 }
 
 impl EditIssueModal {
@@ -274,6 +281,19 @@ impl EditIssueModal {
             active_field: 0,
             error: None,
             submitting: false,
+            is_local: false,
+        }
+    }
+
+    pub fn new_local(id: u64, title: String, body: String) -> Self {
+        Self {
+            number: id,
+            title: TextInput::from(title),
+            body: TextInput::from(body),
+            active_field: 0,
+            error: None,
+            submitting: false,
+            is_local: true,
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -284,6 +284,7 @@ pub fn fetch_sessions(socket_states: &SessionStates, mux: Multiplexer) -> Vec<Ca
                 is_draft: None,
                 is_merged: None,
                 head_branch: None,
+                is_local: false,
             }
         })
         .collect()

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -919,7 +919,7 @@ fn ui_issue_modal(frame: &mut Frame, modal: &IssueModal, spinner_tick: usize) {
     let inner = outer_block.inner(area);
     frame.render_widget(outer_block, area);
 
-    // Layout: title field (3), body field (remaining), checkbox (1), error/spinner (1), hint (1)
+    // Layout: title field (3), body field (remaining), checkbox (1), local toggle (1), error/spinner (1), hint (1)
     let has_error = modal.error.is_some();
     let has_status = has_error || modal.submitting;
     let chunks = Layout::default()
@@ -928,6 +928,7 @@ fn ui_issue_modal(frame: &mut Frame, modal: &IssueModal, spinner_tick: usize) {
             Constraint::Length(3),                              // title input
             Constraint::Min(3),                                 // body input
             Constraint::Length(1),                              // create worktree toggle
+            Constraint::Length(1),                              // local only toggle
             Constraint::Length(if has_status { 1 } else { 0 }), // error or spinner
             Constraint::Length(1),                              // hint
         ])
@@ -1027,6 +1028,30 @@ fn ui_issue_modal(frame: &mut Frame, modal: &IssueModal, spinner_tick: usize) {
     ]));
     frame.render_widget(checkbox, chunks[2]);
 
+    // Local only checkbox
+    let local_icon = if modal.local_only { "[x]" } else { "[ ]" };
+    let local_style = if modal.submitting {
+        Style::default().fg(Color::DarkGray)
+    } else if modal.active_field == 3 {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    let local_checkbox = Paragraph::new(Line::from(vec![
+        Span::styled(format!("{} ", local_icon), local_style),
+        Span::styled(
+            "Local only (not on GitHub)",
+            if modal.submitting {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default().fg(Color::White)
+            },
+        ),
+    ]));
+    frame.render_widget(local_checkbox, chunks[3]);
+
     // Spinner or error
     if modal.submitting {
         let spinner = SPINNER_FRAMES[spinner_tick % SPINNER_FRAMES.len()];
@@ -1044,13 +1069,13 @@ fn ui_issue_modal(frame: &mut Frame, modal: &IssueModal, spinner_tick: usize) {
                     .add_modifier(Modifier::BOLD),
             ),
         ]));
-        frame.render_widget(spinner_text, chunks[3]);
+        frame.render_widget(spinner_text, chunks[4]);
     } else if let Some(err) = &modal.error {
         let err_text = Paragraph::new(Line::from(vec![Span::styled(
             err.as_str(),
             Style::default().fg(Color::Red),
         )]));
-        frame.render_widget(err_text, chunks[3]);
+        frame.render_widget(err_text, chunks[4]);
     }
 
     // Hint
@@ -1063,7 +1088,7 @@ fn ui_issue_modal(frame: &mut Frame, modal: &IssueModal, spinner_tick: usize) {
         hint_text,
         Style::default().fg(Color::DarkGray),
     )]));
-    frame.render_widget(hint, chunks[4]);
+    frame.render_widget(hint, chunks[5]);
 }
 
 fn ui_edit_issue_modal(frame: &mut Frame, modal: &EditIssueModal, spinner_tick: usize) {
@@ -1071,10 +1096,15 @@ fn ui_edit_issue_modal(frame: &mut Frame, modal: &EditIssueModal, spinner_tick: 
 
     frame.render_widget(Clear, area);
 
+    let edit_title = if modal.is_local {
+        format!(" Edit Local Issue L-{} ", modal.number)
+    } else {
+        format!(" Edit Issue #{} ", modal.number)
+    };
     let outer_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Cyan))
-        .title(format!(" Edit Issue #{} ", modal.number))
+        .title(edit_title)
         .title_style(
             Style::default()
                 .fg(Color::Black)


### PR DESCRIPTION
## Summary
- Add local issues that exist only in the app (not on GitHub) and persist between sessions per repo
- Local issues are stored in `~/.config/octopai/local_issues/<repo-slug>.json`
- Local issues display with a cyan "local" tag and "L-" prefix to distinguish them from GitHub issues
- New "Local only" toggle in the issue creation modal (field 3, toggled with Space)
- Full support for editing, closing, and creating worktrees/sessions for local issues

## Test plan
- [ ] Create a new issue with "Local only" toggled on — verify it appears with "local" tag
- [ ] Edit a local issue — verify title/body update persists
- [ ] Close a local issue — verify it disappears from open filter and appears in closed
- [ ] Restart the app — verify local issues persist across sessions
- [ ] Create a worktree from a local issue — verify worktree and session are created
- [ ] Verify GitHub issues still work as before (create, edit, close)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)