### PR TITLE
Add default local issues config and per-issue auto open PR toggle

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub pr_ready: HashMap<String, bool>,
     #[serde(default = "default_auto_open_pr")]
     pub auto_open_pr: HashMap<String, bool>,
+    #[serde(default)]
+    pub default_local: HashMap<String, bool>,
     #[serde(default, alias = "claude_commands")]
     pub session_commands: HashMap<String, String>,
     #[serde(default)]
@@ -64,6 +66,10 @@ pub fn save_config(repo: &str) -> Result<()> {
         .as_ref()
         .map(|c| c.auto_open_pr.clone())
         .unwrap_or_default();
+    let default_local = existing
+        .as_ref()
+        .map(|c| c.default_local.clone())
+        .unwrap_or_default();
     let path = config_path();
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -82,6 +88,7 @@ pub fn save_config(repo: &str) -> Result<()> {
         editor_commands,
         pr_ready,
         auto_open_pr,
+        default_local,
         session_commands,
         multiplexer,
         default_session_command,
@@ -121,6 +128,7 @@ pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
         auto_open_pr: HashMap::new(),
+        default_local: HashMap::new(),
         session_commands: HashMap::new(),
         multiplexer: None,
         default_session_command: None,
@@ -138,6 +146,7 @@ pub fn set_verify_command(repo: &str, command: &str) -> Result<()> {
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
         auto_open_pr: HashMap::new(),
+        default_local: HashMap::new(),
         session_commands: HashMap::new(),
         multiplexer: None,
         default_session_command: None,
@@ -173,6 +182,12 @@ pub fn get_default_session_command() -> Option<String> {
     load_config()?.default_session_command
 }
 
+pub fn get_default_local(repo: &str) -> bool {
+    load_config()
+        .and_then(|c| c.default_local.get(repo).copied())
+        .unwrap_or(false)
+}
+
 pub fn set_default_session_command(command: &str) -> Result<()> {
     let mut config = load_config().unwrap_or(Config {
         repo: String::new(),
@@ -180,6 +195,7 @@ pub fn set_default_session_command(command: &str) -> Result<()> {
         editor_commands: HashMap::new(),
         pr_ready: HashMap::new(),
         auto_open_pr: HashMap::new(),
+        default_local: HashMap::new(),
         session_commands: HashMap::new(),
         multiplexer: None,
         default_session_command: None,

--- a/src/models.rs
+++ b/src/models.rs
@@ -153,9 +153,10 @@ pub struct ConfigEditState {
     pub editor_command: TextInput,
     pub pr_ready: bool,
     pub auto_open_pr: bool,
+    pub default_local: bool,
     pub session_command: TextInput,
     pub multiplexer: crate::session::Multiplexer,
-    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = auto_open_pr, 4 = session_command, 5 = multiplexer
+    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = auto_open_pr, 4 = default_local, 5 = session_command, 6 = multiplexer
 }
 
 impl ConfigEditState {
@@ -164,6 +165,7 @@ impl ConfigEditState {
         editor_command: String,
         pr_ready: bool,
         auto_open_pr: bool,
+        default_local: bool,
         session_command: String,
         multiplexer: crate::session::Multiplexer,
     ) -> Self {
@@ -172,6 +174,7 @@ impl ConfigEditState {
             editor_command: TextInput::from(editor_command),
             pr_ready,
             auto_open_pr,
+            default_local,
             session_command: TextInput::from(session_command),
             multiplexer,
             active_field: 0,
@@ -233,15 +236,16 @@ impl RepoSelectState {
 pub struct IssueModal {
     pub title: TextInput,
     pub body: TextInput,
-    pub active_field: usize, // 0 = title, 1 = body, 2 = create_worktree toggle, 3 = local_only toggle
+    pub active_field: usize, // 0 = title, 1 = body, 2 = create_worktree toggle, 3 = auto_open_pr toggle, 4 = local_only toggle
     pub error: Option<String>,
     pub submitting: bool,
     pub create_worktree: bool,
+    pub auto_open_pr: bool,
     pub local_only: bool,
 }
 
 impl IssueModal {
-    pub fn new() -> Self {
+    pub fn new(default_local: bool, auto_open_pr: bool) -> Self {
         Self {
             title: TextInput::new(),
             body: TextInput::new(),
@@ -249,7 +253,8 @@ impl IssueModal {
             error: None,
             submitting: false,
             create_worktree: true,
-            local_only: false,
+            auto_open_pr,
+            local_only: default_local,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add a `default_local` per-repo config option that defaults the "Local only" checkbox when creating new issues
- Add an "Auto open PR" toggle to the issue creation modal, initialized from the repo's `auto_open_pr` config setting, allowing per-issue override
- Add "Default Local Issues" toggle to the configuration screen for managing the new setting

Closes #1

## Test plan
- [ ] Open config screen (`C`), verify new "Default Local Issues" toggle appears between "Auto Open PRs" and "Session Command"
- [ ] Enable "Default Local Issues" in config, save, then create a new issue (`n`) — verify "Local only" checkbox is pre-checked
- [ ] Create a new issue and verify "Auto open PR" checkbox appears, defaulting to the repo's config value
- [ ] Toggle "Auto open PR" off in the issue modal, create issue with worktree — verify the session prompt does not include PR instructions
- [ ] Verify Tab cycling works correctly through all fields in both the config screen (7 fields) and issue modal (5 fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)