### PR TITLE
Fix local issues using GitHub-specific worktree/session/PR behavior

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -85,9 +85,11 @@ pub fn fetch_worktrees() -> Vec<Card> {
         let tag = "branch";
         let tag_color = Color::Yellow;
 
-        // Link issue-N worktrees to issue cards
+        // Link issue-N worktrees to issue cards, local-N to local issue cards
         let related = if let Some(num) = display_name.strip_prefix("issue-") {
             vec![format!("issue-{}", num)]
+        } else if let Some(num) = display_name.strip_prefix("local-") {
+            vec![format!("local-{}", num)]
         } else {
             Vec::new()
         };

--- a/src/local_issues.rs
+++ b/src/local_issues.rs
@@ -121,7 +121,6 @@ pub fn close_local_issue(repo: &str, id: u64) -> Result<(), String> {
     }
 }
 
-#[allow(dead_code)]
 pub fn fetch_local_issue(repo: &str, id: u64) -> Result<(String, String), String> {
     let store = load_store(repo);
     if let Some(issue) = store.issues.iter().find(|i| i.id == id) {


### PR DESCRIPTION
## Summary
- Local issues now use `local-N` prefix for branches, worktrees, and sessions instead of `issue-N`, preventing naming collisions with GitHub issues
- Skips GitHub API calls (`gh issue edit --add-assignee`) for local issues since they don't exist on GitHub
- Generates local-only AI prompts that instruct to commit changes without opening PRs or referencing GitHub issue numbers
- Updates worktree and session linking to recognize `local-N` branches and fetch local issue data when recreating sessions

## Test plan
- [ ] Create a local issue and press 'w' to create a worktree — verify branch is named `local-N` not `issue-N`
- [ ] Verify the session is named `local-N` and appears in the sessions panel
- [ ] Verify no `gh issue edit` errors in logs for local issues
- [ ] Verify the AI prompt says "local issue L-N" and does not mention opening a PR
- [ ] Create a GitHub issue worktree and verify it still uses `issue-N` naming and opens PRs as before
- [ ] Delete a local issue worktree and verify cleanup works correctly
- [ ] Verify merged PR cleanup does not affect local issue worktrees

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)