### PR TITLE
Fix screen dependency incorrectly shown as missing

### DIFF
--- a/src/deps.rs
+++ b/src/deps.rs
@@ -22,19 +22,32 @@ pub fn check_dependencies() -> Vec<Dependency> {
         check_dep("git", "git", "Version control with worktree support", true),
     ];
 
-    // Terminal multiplexers are optional; tmux is preferred
-    deps.push(check_dep(
+    // Terminal multiplexers: at least one recommended; tmux is preferred
+    let tmux = check_dep(
         "tmux",
         "tmux",
         "Preferred terminal multiplexer for sessions",
         false,
-    ));
-    deps.push(check_dep(
+    );
+    let screen = check_dep(
         "screen",
         "screen",
         "Alternative terminal multiplexer (GNU Screen)",
         false,
-    ));
+    );
+    let mux_available = tmux.available || screen.available;
+    deps.push(Dependency {
+        name: "tmux/screen",
+        description: "Terminal multiplexer for sessions (tmux preferred)",
+        required: false,
+        recommended: true,
+        available: mux_available,
+        version: if tmux.available {
+            tmux.version
+        } else {
+            screen.version
+        },
+    });
 
     // Require at least one AI coding assistant (claude or cursor)
     let claude = check_dep(


### PR DESCRIPTION
## Summary
- Combined tmux and screen into a single `tmux/screen` dependency entry, matching the existing `claude/cursor` pattern
- If either tmux or screen is installed, the dependency shows as OK instead of incorrectly reporting screen as MISSING
- The combined entry is marked as recommended (yellow) when neither is available, rather than showing two separate MISSING entries

## Test plan
- [ ] With tmux installed (no screen): dependency shows `tmux/screen` as OK with tmux version
- [ ] With screen installed (no tmux): dependency shows `tmux/screen` as OK with screen version
- [ ] With neither installed: dependency shows `tmux/screen` as RECOMMENDED in yellow

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)