### PR TITLE
Fix [LOCAL] tag background-colored leading spaces

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -636,8 +636,9 @@ pub fn ui(frame: &mut Frame, app: &App) {
         ),
     ];
     if app.local_mode {
+        repo_spans.push(Span::raw("  "));
         repo_spans.push(Span::styled(
-            "  [LOCAL]",
+            "[LOCAL]",
             Style::default()
                 .fg(Color::Black)
                 .bg(Color::Cyan)


### PR DESCRIPTION
## Summary
- Separated the 2 leading spaces from the `[LOCAL]` tag into an unstyled `Span::raw("  ")` so only the tag text gets the cyan background color, not the preceding whitespace.

Closes #2

## Test plan
- [ ] Run the app in local mode and verify the `[LOCAL]` tag no longer has colored spaces before it

🤖 Generated with [Claude Code](https://claude.com/claude-code)