### PR TITLE
Add local- prefix to local branch worktree and session slugs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -169,13 +169,13 @@ impl App {
 
         // Find the issue key that ties all related cards together.
         // If this IS an issue card, its own id is the key.
-        // Otherwise, look for an issue-N entry in the related field.
-        let issue_key = if card.id.starts_with("issue-") {
+        // Otherwise, look for an issue-N or local-issue-N entry in the related field.
+        let issue_key = if card.id.starts_with("local-issue-") || card.id.starts_with("issue-") {
             Some(card.id.clone())
         } else {
             card.related
                 .iter()
-                .find(|r| r.starts_with("issue-"))
+                .find(|r| r.starts_with("local-issue-") || r.starts_with("issue-"))
                 .cloned()
         };
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,6 +12,14 @@ pub fn get_repo_name(repo: &str) -> &str {
     repo.split('/').next_back().unwrap_or(repo)
 }
 
+/// Extract the issue number from an issue-style identifier like "issue-42" or "local-issue-42".
+/// Returns `None` if the string doesn't match either pattern.
+pub fn extract_issue_number(s: &str) -> Option<u64> {
+    s.strip_prefix("local-issue-")
+        .or_else(|| s.strip_prefix("issue-"))
+        .and_then(|n| n.parse().ok())
+}
+
 /// Detect the GitHub "owner/repo" for the current working directory by
 /// asking `gh` which repository this directory belongs to.
 pub fn detect_current_repo() -> Option<String> {
@@ -85,8 +93,10 @@ pub fn fetch_worktrees() -> Vec<Card> {
         let tag = "branch";
         let tag_color = Color::Yellow;
 
-        // Link issue-N worktrees to issue cards
-        let related = if let Some(num) = display_name.strip_prefix("issue-") {
+        // Link issue-N / local-issue-N worktrees to issue cards
+        let related = if display_name.starts_with("local-issue-") {
+            vec![display_name.clone()]
+        } else if let Some(num) = display_name.strip_prefix("issue-") {
             vec![format!("issue-{}", num)]
         } else {
             Vec::new()

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -61,7 +61,7 @@ pub fn ensure_hook_script() -> std::result::Result<PathBuf, String> {
 # Roctopai event hook - sends Claude session events to the Unix socket
 STATUS="$1"
 cat > /dev/null
-SESSION=$(basename "$PWD" | grep -o 'issue-[0-9]*')
+SESSION=$(basename "$PWD" | grep -oE '(local-)?issue-[0-9]+')
 [ -z "$SESSION" ] && exit 0
 SOCKET="{socket}"
 [ -S "$SOCKET" ] || exit 0

--- a/src/local.rs
+++ b/src/local.rs
@@ -103,7 +103,7 @@ pub fn fetch_local_issues(repo: &str, state: StateFilter, _assignee: AssigneeFil
             };
 
             Card {
-                id: format!("issue-{}", issue.number),
+                id: format!("local-issue-{}", issue.number),
                 title: format!("#{} {}", issue.number, issue.title),
                 description,
                 full_description,
@@ -197,7 +197,9 @@ pub fn fetch_local_prs(repo: &str, state: StateFilter, _assignee: AssigneeFilter
                 ("local", Color::Cyan)
             };
 
-            let related = if let Some(num) = pr.branch.strip_prefix("issue-") {
+            let related = if pr.branch.starts_with("local-issue-") {
+                vec![pr.branch.clone()]
+            } else if let Some(num) = pr.branch.strip_prefix("issue-") {
                 vec![format!("issue-{}", num)]
             } else {
                 Vec::new()

--- a/src/session.rs
+++ b/src/session.rs
@@ -226,7 +226,7 @@ pub fn fetch_sessions(socket_states: &SessionStates, mux: Multiplexer) -> Vec<Ca
 
     session_names
         .into_iter()
-        .filter(|name| name.starts_with("issue-"))
+        .filter(|name| name.starts_with("issue-") || name.starts_with("local-issue-"))
         .map(|name| {
             // Use socket-derived state if available, otherwise fall back
             // to pane content detection.
@@ -532,7 +532,7 @@ pub fn create_session_for_worktree(
     };
 
     // Write prompt to a temp file for safe shell expansion
-    let prompt_file = format!("/tmp/octopai-prompt-{}.txt", number);
+    let prompt_file = format!("/tmp/octopai-prompt-{}.txt", branch);
     fs::write(&prompt_file, &prompt).map_err(|e| format!("Failed to write prompt file: {}", e))?;
 
     // Send session command to the single pane
@@ -573,8 +573,16 @@ pub fn create_worktree_and_session(
     local_mode: bool,
 ) -> std::result::Result<(), String> {
     let repo_name = get_repo_name(repo);
-    let branch = format!("issue-{}", number);
-    let worktree_path = format!("../{}-issue-{}", repo_name, number);
+    let branch = if local_mode {
+        format!("local-issue-{}", number)
+    } else {
+        format!("issue-{}", number)
+    };
+    let worktree_path = if local_mode {
+        format!("../{}-local-issue-{}", repo_name, number)
+    } else {
+        format!("../{}-issue-{}", repo_name, number)
+    };
 
     // Create worktree with new branch
     let output = Command::new("git")
@@ -647,7 +655,7 @@ pub fn create_worktree_and_session(
     };
 
     // Write prompt to a temp file for safe shell expansion
-    let prompt_file = format!("/tmp/octopai-prompt-{}.txt", number);
+    let prompt_file = format!("/tmp/octopai-prompt-{}.txt", branch);
     fs::write(&prompt_file, &prompt).map_err(|e| format!("Failed to write prompt file: {}", e))?;
 
     // Send session command to the single pane


### PR DESCRIPTION
## Summary
- Local mode branches now use `local-issue-{N}` naming instead of `issue-{N}` to avoid collisions with GitHub issue branches
- Updated worktree paths, session names, card IDs, hook script patterns, and issue number extraction across all affected modules
- Added `extract_issue_number()` helper in `git.rs` to handle both `issue-N` and `local-issue-N` patterns

Closes #4

## Test plan
- [ ] Verify local mode creates worktrees with `local-issue-N` branch names
- [ ] Verify local mode sessions are named `local-issue-N`
- [ ] Verify card linking works correctly between local issues, worktrees, sessions, and PRs
- [ ] Verify GitHub mode still uses `issue-N` naming unchanged
- [ ] Verify hook script correctly reports status for both local and GitHub sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)