### PR TITLE
Add per-section loading spinners

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,8 @@ use crate::hooks::ensure_hook_script;
 use crate::models::{
     AiSetupState, AssigneeFilter, Card, ConfigEditState, ConfirmModal, DepInstallConfirm,
     EditIssueModal, IssueEditResult, IssueModal, IssueSubmitResult, MessageLog, Mode,
-    RepoSelectState, Screen, SessionStates, StateFilter, WorktreeCreateResult, MAX_MESSAGES,
+    RepoSelectState, Screen, SectionData, SessionStates, StateFilter, WorktreeCreateResult,
+    MAX_MESSAGES,
 };
 use crate::session::{fetch_sessions, Multiplexer};
 
@@ -54,6 +55,10 @@ pub struct App {
     pub local_mode: bool,
     pub dep_selected: usize,
     pub dep_install_confirm: Option<DepInstallConfirm>,
+    /// Per-section loading state: [issues, worktrees, sessions, pull_requests].
+    pub section_loading: [bool; 4],
+    /// Receiver for per-section async refresh results.
+    pub section_rx: Option<mpsc::Receiver<SectionData>>,
 }
 
 impl App {
@@ -104,6 +109,8 @@ impl App {
             local_mode: false,
             dep_selected: 0,
             dep_install_confirm: None,
+            section_loading: [false; 4],
+            section_rx: None,
         }
     }
 
@@ -345,6 +352,187 @@ impl App {
 
         self.clamp_selected();
         self.last_refresh = Instant::now();
+    }
+
+    /// Launch per-section background threads to fetch data without blocking the UI.
+    /// Each section sends its results via a shared channel as soon as it's ready.
+    pub fn start_async_refresh(&mut self) {
+        self.section_loading = [true; 4];
+        let (tx, rx) = mpsc::channel();
+        self.section_rx = Some(rx);
+
+        let repo = self.repo.clone();
+        let local_mode = self.local_mode;
+
+        // Issues thread
+        let tx_issues = tx.clone();
+        let repo_i = repo.clone();
+        let isf = self.issue_state_filter;
+        let iaf = self.issue_assignee_filter;
+        std::thread::spawn(move || {
+            let issues = if local_mode {
+                crate::local::fetch_local_issues(&repo_i, isf, iaf)
+            } else {
+                fetch_issues(&repo_i, isf, iaf)
+            };
+            let _ = tx_issues.send(SectionData::Issues(issues));
+        });
+
+        // Worktrees thread
+        let tx_wt = tx.clone();
+        std::thread::spawn(move || {
+            let worktrees = fetch_worktrees();
+            let _ = tx_wt.send(SectionData::Worktrees(worktrees));
+        });
+
+        // Sessions thread
+        let tx_sess = tx.clone();
+        let session_states = std::sync::Arc::clone(&self.session_states);
+        let multiplexer = self.multiplexer;
+        std::thread::spawn(move || {
+            let sessions = fetch_sessions(&session_states, multiplexer);
+            let _ = tx_sess.send(SectionData::Sessions(sessions));
+        });
+
+        // Pull Requests thread
+        let tx_pr = tx.clone();
+        let repo_pr = repo.clone();
+        let psf = self.pr_state_filter;
+        let paf = self.pr_assignee_filter;
+        std::thread::spawn(move || {
+            let prs = if local_mode {
+                crate::local::fetch_local_prs(&repo_pr, psf, paf)
+            } else {
+                fetch_prs(&repo_pr, psf, paf)
+            };
+            let _ = tx_pr.send(SectionData::PullRequests(prs));
+        });
+
+        // Main behind count thread
+        std::thread::spawn(move || {
+            let count = fetch_main_behind_count();
+            let _ = tx.send(SectionData::MainBehindCount(count));
+        });
+    }
+
+    /// Run cleanup and auto-nudge logic after all sections have loaded.
+    pub fn post_refresh_cleanup(&mut self) {
+        if self.local_mode {
+            let merged = crate::local::fetch_local_merged_pr_branches(&self.repo);
+            let cleaned = crate::git::cleanup_local_merged_worktrees(
+                &merged,
+                &self.worktrees,
+                self.multiplexer,
+            );
+            if !cleaned.is_empty() {
+                self.set_status(format!("Cleaned up merged: {}", cleaned.join(", ")));
+                self.worktrees = fetch_worktrees();
+            }
+        } else {
+            let cleaned = cleanup_merged_worktrees(&self.repo, &self.worktrees, self.multiplexer);
+            if !cleaned.is_empty() {
+                self.set_status(format!("Cleaned up merged: {}", cleaned.join(", ")));
+                self.worktrees = fetch_worktrees();
+            }
+        }
+
+        self.sessions = fetch_sessions(&self.session_states, self.multiplexer);
+
+        // Auto-nudge idle sessions
+        let max_nudges = 1;
+        enum SessionAction {
+            ClearNudge(String),
+            AutoCreateLocalPr(String),
+            Nudge(String),
+        }
+        let mut actions = Vec::new();
+        for session in &self.sessions {
+            if session.tag != "idle" {
+                continue;
+            }
+            let branch = &session.title;
+            let has_pr = self
+                .pull_requests
+                .iter()
+                .any(|pr| pr.head_branch.as_deref() == Some(branch));
+            if has_pr {
+                actions.push(SessionAction::ClearNudge(branch.clone()));
+                continue;
+            }
+
+            if self.local_mode {
+                if !crate::local::has_local_pr_for_branch(&self.repo, branch)
+                    && crate::git::branch_has_commits(branch)
+                {
+                    actions.push(SessionAction::AutoCreateLocalPr(branch.clone()));
+                }
+                continue;
+            }
+
+            let nudge_count = self.nudged_sessions.entry(branch.clone()).or_insert(0);
+            if *nudge_count >= max_nudges {
+                continue;
+            }
+            *nudge_count += 1;
+            actions.push(SessionAction::Nudge(branch.clone()));
+        }
+
+        for action in actions {
+            match action {
+                SessionAction::ClearNudge(branch) => {
+                    self.nudged_sessions.remove(&branch);
+                }
+                SessionAction::AutoCreateLocalPr(branch) => {
+                    let pr_ready = crate::config::get_pr_ready(&self.repo);
+                    let title = crate::git::first_commit_summary(&branch)
+                        .unwrap_or_else(|| format!("PR for {}", branch));
+                    match crate::local::create_local_pr(&self.repo, &title, "", &branch, !pr_ready)
+                    {
+                        Ok(number) => {
+                            self.set_status(format!(
+                                "Auto-created local PR #{} for {}",
+                                number, branch
+                            ));
+                            self.add_message(&format!(
+                                "[monitor] Auto-created local PR #{} for {}",
+                                number, branch
+                            ));
+                            self.pull_requests = crate::local::fetch_local_prs(
+                                &self.repo,
+                                self.pr_state_filter,
+                                self.pr_assignee_filter,
+                            );
+                        }
+                        Err(e) => {
+                            self.add_message(&format!(
+                                "[monitor] Failed to auto-create local PR for {}: {}",
+                                branch, e
+                            ));
+                        }
+                    }
+                }
+                SessionAction::Nudge(branch) => {
+                    self.multiplexer.send_keys(&branch, "continue");
+                    self.add_message(&format!(
+                        "[monitor] Nudged {} to continue (no PR found)",
+                        branch
+                    ));
+                }
+            }
+        }
+
+        let active_branches: HashSet<String> =
+            self.sessions.iter().map(|s| s.title.clone()).collect();
+        self.nudged_sessions
+            .retain(|k, _| active_branches.contains(k));
+
+        self.clamp_selected();
+        self.last_refresh = Instant::now();
+    }
+
+    /// Returns true if any section is currently loading asynchronously.
+    pub fn is_section_loading(&self) -> bool {
+        self.section_loading.iter().any(|&x| x)
     }
 
     pub fn enter_repo_select(&mut self) {

--- a/src/models.rs
+++ b/src/models.rs
@@ -303,6 +303,15 @@ pub enum WorktreeCreateResult {
     },
 }
 
+/// Result sent from per-section background refresh threads.
+pub enum SectionData {
+    Issues(Vec<Card>),
+    Worktrees(Vec<Card>),
+    Sessions(Vec<Card>),
+    PullRequests(Vec<Card>),
+    MainBehindCount(usize),
+}
+
 pub fn fuzzy_match(query: &str, target: &str) -> bool {
     let target_lower = target.to_lowercase();
     let mut target_chars = target_lower.chars();


### PR DESCRIPTION
## Summary
- Replace blocking synchronous data refresh with parallel async fetching per section (issues, worktrees, sessions, PRs)
- Each column shows its own animated spinner in the header and body while its data loads
- The board renders immediately on startup instead of blocking until all GitHub/git data is fetched
- Auto-refresh and manual refresh (R) also use non-blocking async refresh

## Test plan
- [ ] Launch the app and verify the board appears immediately with per-section spinners
- [ ] Verify each column populates independently as its data arrives
- [ ] Verify column headers show spinner animation while loading, then switch to count when done
- [ ] Press R and verify non-blocking refresh with spinners
- [ ] Verify auto-refresh (30s timer) still works correctly
- [ ] Test repo switching — spinners should appear in the new context

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)