### PR TITLE
Remove 30s automatic refresh timer

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,11 +1,8 @@
+use ratatui::style::Color;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-
-use ratatui::style::Color;
 
 pub const SOCKET_PATH: &str = "/tmp/octopai-events.sock";
-pub const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 pub const MAX_MESSAGES: usize = 100;
 
 pub type SessionStates = Arc<Mutex<HashMap<String, String>>>;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::time::Duration;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -14,7 +13,7 @@ use crate::config::config_path;
 use crate::deps::Dependency;
 use crate::models::{
     card_matches, AiSetupState, Card, ConfirmModal, DepInstallConfirm, EditIssueModal, IssueModal,
-    Mode, RepoSelectPhase, RepoSelectState, StateFilter, TextInput, REFRESH_INTERVAL,
+    Mode, RepoSelectPhase, RepoSelectState, StateFilter, TextInput,
 };
 use crate::session::{
     default_editor_command, COMMAND_SHORTCUTS, DEFAULT_CLAUDE_COMMAND, DEFAULT_EDITOR_COMMAND,
@@ -996,31 +995,9 @@ pub fn ui(frame: &mut Frame, app: &App) {
         .constraints([Constraint::Length(1), Constraint::Length(1)])
         .split(outer[3]);
 
-    // Top row: global actions with timer on right
-    let top_bottom = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(0), Constraint::Length(14)])
-        .split(bottom_rows[0]);
-
+    // Top row: global actions
     let global_legend = Paragraph::new(Line::from(global_spans));
-    frame.render_widget(global_legend, top_bottom[0]);
-
-    // Refresh countdown timer
-    let remaining = REFRESH_INTERVAL
-        .checked_sub(app.last_refresh.elapsed())
-        .unwrap_or(Duration::ZERO);
-    let secs = remaining.as_secs();
-    let timer_text = format!(" ⏱ {}s ", secs);
-    let timer_style = if secs <= 5 {
-        Style::default()
-            .fg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::DarkGray)
-    };
-    let timer = Paragraph::new(Line::from(Span::styled(timer_text, timer_style)))
-        .alignment(ratatui::layout::Alignment::Right);
-    frame.render_widget(timer, top_bottom[1]);
+    frame.render_widget(global_legend, bottom_rows[0]);
 
     // Bottom row: area-specific actions
     let area_legend = Paragraph::new(Line::from(area_spans));


### PR DESCRIPTION
## Summary
- Removed the `REFRESH_INTERVAL` constant and the automatic 30-second periodic refresh that triggered `start_async_refresh()` on the Board screen
- Removed the countdown timer UI widget (⏱) from the bottom status bar
- Simplified the event poll timeout logic since it no longer needs to tick every second for the timer display
- Users can still manually refresh data using the `r` keybinding

Closes #172

## Test plan
- [ ] Verify the app compiles cleanly (`cargo check` passes with no warnings)
- [ ] Confirm no automatic refresh occurs while idle on the Board screen
- [ ] Confirm the countdown timer is no longer displayed in the bottom bar
- [ ] Verify manual refresh (`r` key) still works
- [ ] Verify delayed refresh after PR merge still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)