### PR TITLE
Default PR list to current user's assignments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -89,7 +89,7 @@ impl App {
             issue_state_filter: StateFilter::Open,
             issue_assignee_filter: AssigneeFilter::All,
             pr_state_filter: StateFilter::Open,
-            pr_assignee_filter: AssigneeFilter::All,
+            pr_assignee_filter: AssigneeFilter::Mine,
             issue_submit_rx: None,
             issue_edit_rx: None,
             edit_issue_modal: None,


### PR DESCRIPTION
## Summary
- Changed the default PR assignee filter from `All` to `Mine` so the Pull Requests column only shows PRs assigned to the current user on startup
- Users can still toggle between "mine" and "all" using the `m` key

## Test plan
- [ ] Launch octopai and verify the PR column header shows `[open|mine]` by default
- [ ] Verify only PRs assigned to the current user are listed
- [ ] Press `m` to toggle to "all" and confirm all PRs appear
- [ ] Press `m` again to toggle back to "mine"

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)