### PR TITLE
Default config should not create PRs automatically

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -164,7 +164,7 @@ pub fn get_pr_ready(repo: &str) -> bool {
 pub fn get_auto_open_pr(repo: &str) -> bool {
     load_config()
         .and_then(|c| c.auto_open_pr.get(repo).copied())
-        .unwrap_or(true)
+        .unwrap_or(false)
 }
 
 pub fn get_session_command(repo: &str) -> Option<String> {


### PR DESCRIPTION
## Summary

- Changed the default value of `auto_open_pr` from `true` to `false` in `get_auto_open_pr()`
- Previously, when a repository had no explicit `auto_open_pr` setting in config, PRs were created automatically during AI sessions
- Now users must explicitly opt in to automatic PR creation via the config UI (press `C`)

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)