### PR TITLE
Add configurable auto-refresh interval

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,9 @@ pub struct Config {
     /// Whether to operate in local-only mode (no GitHub API calls).
     #[serde(default)]
     pub local_mode: Option<bool>,
+    /// Automatic refresh interval in seconds. 0 or absent means no auto-refresh.
+    #[serde(default)]
+    pub auto_refresh_secs: Option<u64>,
 }
 
 pub fn config_path() -> PathBuf {
@@ -79,6 +82,7 @@ pub fn save_config(repo: &str) -> Result<()> {
         .as_ref()
         .and_then(|c| c.default_session_command.clone());
     let local_mode = existing.as_ref().and_then(|c| c.local_mode);
+    let auto_refresh_secs = existing.as_ref().and_then(|c| c.auto_refresh_secs);
     let multiplexer = existing.and_then(|c| c.multiplexer);
     let config = Config {
         repo: repo.to_string(),
@@ -90,6 +94,7 @@ pub fn save_config(repo: &str) -> Result<()> {
         multiplexer,
         default_session_command,
         local_mode,
+        auto_refresh_secs,
     };
     fs::write(path, serde_json::to_string_pretty(&config)?)?;
     Ok(())
@@ -130,6 +135,7 @@ pub fn set_editor_command(repo: &str, command: &str) -> Result<()> {
         multiplexer: None,
         default_session_command: None,
         local_mode: None,
+        auto_refresh_secs: None,
     });
     config
         .editor_commands
@@ -148,6 +154,7 @@ pub fn set_verify_command(repo: &str, command: &str) -> Result<()> {
         multiplexer: None,
         default_session_command: None,
         local_mode: None,
+        auto_refresh_secs: None,
     });
     config
         .verify_commands
@@ -191,6 +198,7 @@ pub fn set_default_session_command(command: &str) -> Result<()> {
         multiplexer: None,
         default_session_command: None,
         local_mode: None,
+        auto_refresh_secs: None,
     });
     config.default_session_command = Some(command.to_string());
     save_full_config(&config)
@@ -211,7 +219,12 @@ pub fn set_local_mode(enabled: bool) -> Result<()> {
         multiplexer: None,
         default_session_command: None,
         local_mode: None,
+        auto_refresh_secs: None,
     });
     config.local_mode = Some(enabled);
     save_full_config(&config)
+}
+
+pub fn get_auto_refresh_secs() -> u64 {
+    load_config().and_then(|c| c.auto_refresh_secs).unwrap_or(0)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use models::{
     AiSetupState, ConfigEditState, ConfirmAction, ConfirmModal, DepInstallConfirm, EditIssueModal,
     IssueEditResult, IssueModal, IssueSubmitResult, MergeStrategy, MessageLog, Mode,
     RepoSelectPhase, Screen, SectionData, SessionStates, StateFilter, TextInput,
-    WorktreeCreateResult, REFRESH_INTERVAL, SOCKET_PATH,
+    WorktreeCreateResult, SOCKET_PATH,
 };
 use session::{
     create_session_for_worktree, create_worktree_and_session, ensure_main_session,
@@ -152,9 +152,11 @@ fn main() -> Result<()> {
         })?;
 
         // Auto-refresh when interval has elapsed and on Board screen in Normal mode
-        if app.screen == Screen::Board
+        let auto_refresh_secs = config::get_auto_refresh_secs();
+        if auto_refresh_secs > 0
+            && app.screen == Screen::Board
             && app.mode == Mode::Normal
-            && app.last_refresh.elapsed() >= REFRESH_INTERVAL
+            && app.last_refresh.elapsed() >= Duration::from_secs(auto_refresh_secs)
             && !app.is_section_loading()
         {
             app.start_async_refresh();
@@ -317,8 +319,9 @@ fn main() -> Result<()> {
         let poll_timeout = if has_spinner {
             // Fast polling for spinner animation
             Duration::from_millis(100)
-        } else if app.screen == Screen::Board && app.mode == Mode::Normal {
-            let remaining = REFRESH_INTERVAL
+        } else if auto_refresh_secs > 0 && app.screen == Screen::Board && app.mode == Mode::Normal {
+            let interval = Duration::from_secs(auto_refresh_secs);
+            let remaining = interval
                 .checked_sub(app.last_refresh.elapsed())
                 .unwrap_or(Duration::ZERO);
             // Cap at 1 second so the countdown timer display stays current
@@ -528,7 +531,7 @@ fn main() -> Result<()> {
                                 app.screen = Screen::Board;
                             }
                             KeyCode::Tab => {
-                                config_edit.active_field = (config_edit.active_field + 1) % 6;
+                                config_edit.active_field = (config_edit.active_field + 1) % 7;
                             }
                             KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                                 let verify_cmd =
@@ -575,6 +578,17 @@ fn main() -> Result<()> {
                                             .insert(repo.clone(), claude_cmd.clone());
                                     }
                                     config.multiplexer = Some(config_edit.multiplexer);
+                                    let refresh_val: u64 = config_edit
+                                        .refresh_interval
+                                        .value()
+                                        .trim()
+                                        .parse()
+                                        .unwrap_or(0);
+                                    config.auto_refresh_secs = if refresh_val == 0 {
+                                        None
+                                    } else {
+                                        Some(refresh_val)
+                                    };
                                     let _ = config::save_full_config(&config);
                                 }
 
@@ -587,30 +601,35 @@ fn main() -> Result<()> {
                                 0 => config_edit.verify_command.delete_back(),
                                 1 => config_edit.editor_command.delete_back(),
                                 4 => config_edit.session_command.delete_back(),
+                                6 => config_edit.refresh_interval.delete_back(),
                                 _ => {}
                             },
                             KeyCode::Left => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_left(),
                                 1 => config_edit.editor_command.move_left(),
                                 4 => config_edit.session_command.move_left(),
+                                6 => config_edit.refresh_interval.move_left(),
                                 _ => {}
                             },
                             KeyCode::Right => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_right(),
                                 1 => config_edit.editor_command.move_right(),
                                 4 => config_edit.session_command.move_right(),
+                                6 => config_edit.refresh_interval.move_right(),
                                 _ => {}
                             },
                             KeyCode::Home => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_home(),
                                 1 => config_edit.editor_command.move_home(),
                                 4 => config_edit.session_command.move_home(),
+                                6 => config_edit.refresh_interval.move_home(),
                                 _ => {}
                             },
                             KeyCode::End => match config_edit.active_field {
                                 0 => config_edit.verify_command.move_end(),
                                 1 => config_edit.editor_command.move_end(),
                                 4 => config_edit.session_command.move_end(),
+                                6 => config_edit.refresh_interval.move_end(),
                                 _ => {}
                             },
                             KeyCode::Char(' ') | KeyCode::Enter
@@ -635,6 +654,7 @@ fn main() -> Result<()> {
                                 0 => config_edit.verify_command.insert(c),
                                 1 => config_edit.editor_command.insert(c),
                                 4 => config_edit.session_command.insert(c),
+                                6 if c.is_ascii_digit() => config_edit.refresh_interval.insert(c),
                                 _ => {}
                             },
                             _ => {}
@@ -1155,6 +1175,7 @@ fn main() -> Result<()> {
                                     let current_auto_open_pr = get_auto_open_pr(&app.repo);
                                     let current_claude =
                                         get_session_command(&app.repo).unwrap_or_default();
+                                    let current_refresh_secs = config::get_auto_refresh_secs();
                                     app.config_edit = Some(ConfigEditState::new(
                                         current_verify,
                                         current_editor,
@@ -1162,6 +1183,7 @@ fn main() -> Result<()> {
                                         current_auto_open_pr,
                                         current_claude,
                                         app.multiplexer,
+                                        current_refresh_secs,
                                     ));
                                     app.screen = Screen::Configuration;
                                 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,11 +1,9 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use ratatui::style::Color;
 
 pub const SOCKET_PATH: &str = "/tmp/octopai-events.sock";
-pub const REFRESH_INTERVAL: Duration = Duration::from_secs(30);
 pub const MAX_MESSAGES: usize = 100;
 
 pub type SessionStates = Arc<Mutex<HashMap<String, String>>>;
@@ -160,7 +158,8 @@ pub struct ConfigEditState {
     pub auto_open_pr: bool,
     pub session_command: TextInput,
     pub multiplexer: crate::session::Multiplexer,
-    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = auto_open_pr, 4 = session_command, 5 = multiplexer
+    pub refresh_interval: TextInput,
+    pub active_field: usize, // 0 = verify, 1 = editor, 2 = pr_ready, 3 = auto_open_pr, 4 = session_command, 5 = multiplexer, 6 = refresh_interval
 }
 
 impl ConfigEditState {
@@ -171,7 +170,13 @@ impl ConfigEditState {
         auto_open_pr: bool,
         session_command: String,
         multiplexer: crate::session::Multiplexer,
+        auto_refresh_secs: u64,
     ) -> Self {
+        let refresh_text = if auto_refresh_secs == 0 {
+            String::new()
+        } else {
+            auto_refresh_secs.to_string()
+        };
         Self {
             verify_command: TextInput::from(verify_command),
             editor_command: TextInput::from(editor_command),
@@ -179,6 +184,7 @@ impl ConfigEditState {
             auto_open_pr,
             session_command: TextInput::from(session_command),
             multiplexer,
+            refresh_interval: TextInput::from(refresh_text),
             active_field: 0,
         }
     }


### PR DESCRIPTION
## Summary
- Adds an `auto_refresh_secs` config option to control automatic board refresh timing
- When set to 0 or left blank (default), auto-refresh is disabled — users refresh manually with `R`
- When set to a positive number of seconds, the board refreshes automatically with a countdown timer in the status bar
- The setting is editable from the Configuration screen (`C` key) as a new "Auto Refresh Interval (seconds)" field that only accepts digit input

## Changes
- **config.rs**: Added `auto_refresh_secs` field to `Config` struct with serde default, plus `get_auto_refresh_secs()` getter
- **models.rs**: Added `refresh_interval` text input to `ConfigEditState`, removed unused `REFRESH_INTERVAL` constant
- **main.rs**: Auto-refresh and poll timeout now use the configured interval instead of the hardcoded constant; config screen handles the new field (Tab navigation, text input, save)
- **ui.rs**: Configuration screen renders the new field with placeholder "0 (disabled)"; countdown timer only shows when auto-refresh is enabled

## Test plan
- [ ] Launch octopai, open Configuration (`C`), verify the new "Auto Refresh Interval (seconds)" field appears after the multiplexer toggle
- [ ] Confirm the field defaults to empty with "0 (disabled)" placeholder
- [ ] Set the value to `30`, save with Ctrl+S, verify the countdown timer appears on the board
- [ ] Confirm the board auto-refreshes when the timer reaches 0
- [ ] Clear the value or set to `0`, save, verify no timer is shown and no auto-refresh occurs
- [ ] Verify only digit characters can be typed in the field

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)