### PR TITLE
Default issues assignee filter to Mine

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -90,7 +90,7 @@ impl App {
             session_states,
             hook_script_path,
             issue_state_filter: StateFilter::Open,
-            issue_assignee_filter: AssigneeFilter::All,
+            issue_assignee_filter: AssigneeFilter::Mine,
             pr_state_filter: StateFilter::Open,
             pr_assignee_filter: AssigneeFilter::Mine,
             issue_submit_rx: None,


### PR DESCRIPTION
## Summary
- Changes the default issue assignee filter from "All" to "Mine", so the Issues column shows only issues assigned to the current user on startup
- Matches the existing Pull Requests default behavior
- Users can still toggle between "all" and "mine" with the `m` key

Closes #182

## Test plan
- [ ] Launch the app and verify the Issues column header shows `[open|mine]` by default
- [ ] Press `m` to toggle to "all" and back to "mine" to confirm toggling still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)