### PR TITLE
Auto-assign pull requests to current user

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use crate::deps::Dependency;
 use crate::git::{cleanup_merged_worktrees, fetch_main_behind_count, fetch_worktrees};
-use crate::github::fetch_prs;
+use crate::github::{assign_pr, fetch_prs};
 
 use crate::hooks::ensure_hook_script;
 use crate::models::{
@@ -231,6 +231,15 @@ impl App {
             );
             self.pull_requests =
                 fetch_prs(&self.repo, self.pr_state_filter, self.pr_assignee_filter);
+
+            // Auto-assign unassigned PRs to the current user
+            for card in &self.pull_requests {
+                if card.is_assigned == Some(false) {
+                    if let Some(number) = card.pr_number {
+                        assign_pr(&self.repo, number);
+                    }
+                }
+            }
         }
         self.worktrees = fetch_worktrees();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -115,6 +115,7 @@ pub fn fetch_worktrees() -> Vec<Card> {
             is_draft: None,
             is_merged: None,
             head_branch: None,
+            is_assigned: None,
         });
     }
 

--- a/src/local.rs
+++ b/src/local.rs
@@ -115,6 +115,7 @@ pub fn fetch_local_issues(repo: &str, state: StateFilter, _assignee: AssigneeFil
                 is_draft: None,
                 is_merged: None,
                 head_branch: None,
+                is_assigned: None,
             }
         })
         .collect();
@@ -218,6 +219,7 @@ pub fn fetch_local_prs(repo: &str, state: StateFilter, _assignee: AssigneeFilter
                 is_draft: Some(pr.is_draft),
                 is_merged: Some(pr.state == "merged"),
                 head_branch: Some(pr.branch.clone()),
+                is_assigned: None,
             }
         })
         .collect();

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,6 +22,7 @@ pub struct Card {
     pub is_draft: Option<bool>,
     pub is_merged: Option<bool>,
     pub head_branch: Option<String>,
+    pub is_assigned: Option<bool>,
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -284,6 +284,7 @@ pub fn fetch_sessions(socket_states: &SessionStates, mux: Multiplexer) -> Vec<Ca
                 is_draft: None,
                 is_merged: None,
                 head_branch: None,
+                is_assigned: None,
             }
         })
         .collect()


### PR DESCRIPTION
## Summary
- Fetch assignee data when listing PRs from GitHub
- Automatically assign any unassigned PRs to the current user (`@me`) during each data refresh
- Added `assign_pr()` helper that calls `gh pr edit --add-assignee @me`

Closes #185

## Test plan
- [ ] Open the app with a repo that has unassigned PRs and verify they get assigned on refresh
- [ ] Verify already-assigned PRs are not affected
- [ ] Verify local mode is unaffected (no GitHub API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)