### PR TITLE
Bump version to 0.3.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "octopai"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "color-eyre",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "octopai"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "AI-powered CLI assistant for managing multiple projects"
 homepage = "https://github.com/dgriffith0/octopai"


### PR DESCRIPTION
## Summary
- Bumps version from 0.2.0 to 0.3.0 in `Cargo.toml` and `Cargo.lock`
- After merging, tag with `v0.3.0` to trigger the cargo-dist release workflow

### Changes since v0.2.0
- Per-section loading spinners for async data refresh
- Configurable auto-refresh interval setting
- Faster GitHub issues search with server-side queries
- Auto-assign pull requests to current user
- Default assignee filters to "Mine" for issues and PRs
- Default `auto_open_pr` to false
- Fix UI not re-rendering after async operations complete

## Test plan
- [x] `cargo check` passes
- [ ] Merge and tag `v0.3.0` to trigger release workflow

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)